### PR TITLE
Feat:태그 렌더링 문제 해결

### DIFF
--- a/Modi-frontend/src/components/DiaryPage/KeywordInput.tsx
+++ b/Modi-frontend/src/components/DiaryPage/KeywordInput.tsx
@@ -1,4 +1,4 @@
-import { useNavigate } from "react-router-dom";
+/*import { useNavigate } from "react-router-dom";
 import { WithContext as ReactTags, Tag } from "react-tag-input";
 import { useDiaryDraft } from "../../hooks/useDiaryDraft";
 import styles from "./KeywordInput.module.css";
@@ -60,4 +60,4 @@ const KeywordInput = () => {
   );
 };
 
-export default KeywordInput;
+export default KeywordInput;*/

--- a/Modi-frontend/src/components/HomePage/Diary/Polaroid/EmotionTagList.tsx
+++ b/Modi-frontend/src/components/HomePage/Diary/Polaroid/EmotionTagList.tsx
@@ -18,8 +18,12 @@ const EmotionTagList: React.FC<Props> = ({ tags }) => {
 
   return (
     <div className={styles.wrapper}>
-      {displayed.map((tag) => (
-        <EmotionTag key={tag} label={tag} type={selectedCharacter} />
+      {displayed.map((tag, idx) => (
+        <EmotionTag
+          key={`${tag}-${idx}`}
+          label={tag}
+          type={selectedCharacter}
+        />
       ))}
     </div>
   );

--- a/Modi-frontend/src/components/HomePage/Diary/Polaroid/PolaroidDiary.module.css
+++ b/Modi-frontend/src/components/HomePage/Diary/Polaroid/PolaroidDiary.module.css
@@ -34,4 +34,5 @@
 .wrapper {
   display: flex;
   gap: 4px;
+  flex-wrap: wrap;
 }

--- a/Modi-frontend/src/components/HomePage/Diary/Polaroid/PolaroidDiary.module.css
+++ b/Modi-frontend/src/components/HomePage/Diary/Polaroid/PolaroidDiary.module.css
@@ -1,6 +1,6 @@
 .container {
   position: absolute;
-  top: 190px;
+  top: 192px;
   left: 50px;
   right: 50px;
 }
@@ -15,6 +15,11 @@
   padding: 0;
 }
 
+.character {
+  position: absolute;
+  top: 6px;
+}
+
 .tags {
   display: flex;
   flex-wrap: wrap;
@@ -24,15 +29,34 @@
 }
 
 .info {
+  position: relative;
   display: flex;
   align-items: flex-end;
   gap: 9px;
   padding: 0 16px;
-  margin-top: 16px;
 }
 
 .wrapper {
   display: flex;
-  gap: 4px;
+  gap: 8px;
   flex-wrap: wrap;
+  justify-content: center;
+}
+
+.wrapper > :nth-child(1) {
+  position: absolute;
+  top: 30px;
+  right: 42px;
+}
+
+.wrapper > :nth-child(2) {
+  position: absolute;
+  top: 78px;
+  right: 16px;
+}
+
+.wrapper > :nth-child(3) {
+  position: absolute;
+  top: 126px;
+  right: 57px;
 }

--- a/Modi-frontend/src/components/HomePage/Diary/Polaroid/PolaroidDiary.tsx
+++ b/Modi-frontend/src/components/HomePage/Diary/Polaroid/PolaroidDiary.tsx
@@ -29,7 +29,10 @@ const PolaroidDiary: React.FC<PolaroidDiaryProps> = ({
       summary={content}
     />
     <div className={styles.info}>
-      <EmotionCharacter emotion={emotion} />
+      <div className={styles.character}>
+        <EmotionCharacter emotion={emotion} />
+      </div>
+
       <EmotionTagList tags={tags} />
     </div>
   </div>

--- a/Modi-frontend/src/components/tag/EmotionTag/EmotionTag.module.css
+++ b/Modi-frontend/src/components/tag/EmotionTag/EmotionTag.module.css
@@ -8,17 +8,17 @@
   align-items: center;
   gap: 9px;
   flex-shrink: 0;
-  border-radius: 5.647px;
+  border-radius: 7px;
   border: 0.941px solid var(--gray3, #9c9c9c);
   background: var(--color1, #fbfbfb);
 }
 
 .inner-border {
-  width: 115.765px;
-  height: 22.588px;
+  width: 117.765px;
+  height: 26.588px;
   flex-shrink: 0;
-  border-radius: 3.765px;
-  border: 0.941px solid;
+  border-radius: 5px;
+  border: 1px solid;
   background: var(--color1, #fbfbfb);
 
   display: flex;

--- a/Modi-frontend/src/components/tag/EmotionTag/EmotionTag.module.css
+++ b/Modi-frontend/src/components/tag/EmotionTag/EmotionTag.module.css
@@ -28,10 +28,6 @@
 }
 
 .label {
-  position: absolute;
-  right: 45.882px;
-  top: 5px;
-
   color: #2c2c2c;
   text-align: center;
   font-feature-settings: "liga" off, "clig" off;

--- a/Modi-frontend/src/data/diaries.ts
+++ b/Modi-frontend/src/data/diaries.ts
@@ -27,6 +27,7 @@ export const allDiaries: Diary[] = [
     photoUrl: "/img/1.jpg",
     summary: "일기 내용 한 줄 요약",
     emotion: "기쁨",
+    tags: ["#태그2", "#태그2", "#태그2"],
   },
   {
     id: 2,
@@ -34,6 +35,7 @@ export const allDiaries: Diary[] = [
     photoUrl: "/img/2.jpg",
     summary: "일기 내용 한 줄 요약",
     emotion: "슬픔",
+    tags: ["#태그3", "#태그3", "#태그3"],
   },
   {
     id: 3,
@@ -41,6 +43,7 @@ export const allDiaries: Diary[] = [
     photoUrl: "/img/3.jpg",
     summary: "일기 내용 한 줄 요약",
     emotion: "보통",
+    tags: ["#태그1", "#태그1", "#태그1"],
   },
   // …필요한 만큼 추가
 ];

--- a/Modi-frontend/src/pages/diary/DiaryKeywordPage.tsx
+++ b/Modi-frontend/src/pages/diary/DiaryKeywordPage.tsx
@@ -2,7 +2,7 @@ import styles from "./DiaryKeywordPage.module.css";
 import Header from "../../components/common/Header";
 import PrimaryButton from "../../components/common/button/ButtonBar/PrimaryButton";
 import { useNavigate } from "react-router-dom";
-import KeywordInput from "../../components/DiaryPage/KeywordInput";
+//import KeywordInput from "../../components/DiaryPage/KeywordInput";
 
 const DiaryKeywordPage = () => {
   const navigate = useNavigate();
@@ -11,7 +11,7 @@ const DiaryKeywordPage = () => {
     <div className={styles.DiaryKeyword_wrapper}>
       <div className={styles.DiaryKeyword_container}>
         <Header />
-        <KeywordInput />
+        {/*<KeywordInput />*/}
         <PrimaryButton
           location="next"
           label="완료"

--- a/Modi-frontend/src/pages/diary/DiaryWritePage.tsx
+++ b/Modi-frontend/src/pages/diary/DiaryWritePage.tsx
@@ -4,7 +4,7 @@ import styles from "./DiaryWritePage.module.css";
 import Header from "../../components/common/Header";
 import PrimaryButton from "../../components/common/button/ButtonBar/PrimaryButton";
 import AddressInput from "../../components/DiaryPage/AddressInput";
-import KeywordInput from "../../components/DiaryPage/KeywordInput";
+//import KeywordInput from "../../components/DiaryPage/KeywordInput";
 
 const DiaryWritePage = () => {
   const fileInputRef = useRef<HTMLInputElement | null>(null);
@@ -127,8 +127,7 @@ const DiaryWritePage = () => {
           {/* 주소 입력 */}
           <AddressInput />
 
-          {/* 키워드 */}
-          <KeywordInput />
+          {/* 키워드 <KeywordInput /> */}
 
           {/* 내용 */}
           <div className={styles.input_group}>

--- a/Modi-frontend/src/routes/router.tsx
+++ b/Modi-frontend/src/routes/router.tsx
@@ -22,6 +22,10 @@ const Router = () => {
       element: <HomePage />,
     },
     {
+      path: "/test-home",
+      element: <HomePage />,
+    },
+    {
       path: "/search",
       element: <SearchPage />,
     },


### PR DESCRIPTION
### 구현사항
- 폴라로이드 일기 아래 태그가 렌더링 되지 않는 문제 해결
- 각각의 태그 위치 조정
<img width="423" height="867" alt="image" src="https://github.com/user-attachments/assets/dc931ad9-a934-4225-a717-5ef49f0463d5" />

### 참고사항
- 아직 임시 데이터를 사용하기 때문에 각각 일기 별로 임시로 태그 이름을 설정했습니다 (예: 태그1, 태그2, 태그3)
- 오류가 발생한 코드는 임시로 주석 처리해 두었음을 양해 부탁 드립니다!
