### PR TITLE
Feat/Design: 이전·다음 일기 컴포넌트, 감정칩 토글 기능 추가 및 레이아웃 CSS 개선

### DIFF
--- a/Modi-frontend/package-lock.json
+++ b/Modi-frontend/package-lock.json
@@ -12,12 +12,12 @@
         "exifreader": "^4.31.1",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
-        "react-router-dom": "^7.6.3",
+        "react-router-dom": "^7.7.0",
         "react-tag-input": "^6.10.6"
       },
       "devDependencies": {
         "@eslint/js": "^9.25.0",
-        "@types/node": "^24.0.13",
+        "@types/node": "^24.0.15",
         "@types/react": "^19.1.8",
         "@types/react-dom": "^19.1.6",
         "@vitejs/plugin-react": "^4.6.0",
@@ -1963,9 +1963,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "24.0.13",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.13.tgz",
-      "integrity": "sha512-Qm9OYVOFHFYg3wJoTSrz80hoec5Lia/dPp84do3X7dZvLikQvM1YpmvTBEdIr/e+U8HTkFjLHLnl78K/qjf+jQ==",
+      "version": "24.0.15",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.15.tgz",
+      "integrity": "sha512-oaeTSbCef7U/z7rDeJA138xpG3NuKc64/rZ2qmUFkFJmnMsAPaluIifqyWd8hSSMxyP9oie3dLAqYPblag9KgA==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -3740,9 +3740,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.6.3.tgz",
-      "integrity": "sha512-zf45LZp5skDC6I3jDLXQUu0u26jtuP4lEGbc7BbdyxenBN1vJSTA18czM2D+h5qyMBuMrD+9uB+mU37HIoKGRA==",
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.7.0.tgz",
+      "integrity": "sha512-3FUYSwlvB/5wRJVTL/aavqHmfUKe0+Xm9MllkYgGo9eDwNdkvwlJGjpPxono1kCycLt6AnDTgjmXvK3/B4QGuw==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
@@ -3762,12 +3762,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.6.3.tgz",
-      "integrity": "sha512-DiWJm9qdUAmiJrVWaeJdu4TKu13+iB/8IEi0EW/XgaHCjW/vWGrwzup0GVvaMteuZjKnh5bEvJP/K0MDnzawHw==",
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.7.0.tgz",
+      "integrity": "sha512-wwGS19VkNBkneVh9/YD0pK3IsjWxQUVMDD6drlG7eJpo1rXBtctBqDyBm/k+oKHRAm1x9XWT3JFC82QI9YOXXA==",
       "license": "MIT",
       "dependencies": {
-        "react-router": "7.6.3"
+        "react-router": "7.7.0"
       },
       "engines": {
         "node": ">=20.0.0"

--- a/Modi-frontend/package.json
+++ b/Modi-frontend/package.json
@@ -14,12 +14,12 @@
     "exifreader": "^4.31.1",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
-    "react-router-dom": "^7.6.3",
+    "react-router-dom": "^7.7.0",
     "react-tag-input": "^6.10.6"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",
-    "@types/node": "^24.0.13",
+    "@types/node": "^24.0.15",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
     "@vitejs/plugin-react": "^4.6.0",

--- a/Modi-frontend/src/components/HomePage/Diary/Polaroid/PolaroidDiary.module.css
+++ b/Modi-frontend/src/components/HomePage/Diary/Polaroid/PolaroidDiary.module.css
@@ -1,8 +1,8 @@
 .container {
-  position: absolute;
-  top: 192px;
-  left: 50px;
-  right: 50px;
+  position: relative;
+  top: 80px;
+  width: 360px;
+  height: 580px;
 }
 
 .info {

--- a/Modi-frontend/src/components/HomePage/Diary/Polaroid/PolaroidDiary.tsx
+++ b/Modi-frontend/src/components/HomePage/Diary/Polaroid/PolaroidDiary.tsx
@@ -32,7 +32,6 @@ const PolaroidDiary: React.FC<PolaroidDiaryProps> = ({
       <div className={styles.character}>
         <EmotionCharacter emotion={emotion} />
       </div>
-
       <EmotionTagList tags={tags} />
     </div>
   </div>

--- a/Modi-frontend/src/components/HomePage/Diary/Polaroid/PolaroidDiary.tsx
+++ b/Modi-frontend/src/components/HomePage/Diary/Polaroid/PolaroidDiary.tsx
@@ -10,7 +10,6 @@ export interface PolaroidDiaryProps {
   photoUrl: string;
   emotion: Emotion;
   content: string;
-  clicked: boolean;
   tags?: string[];
 }
 

--- a/Modi-frontend/src/components/HomePage/EmotionTab/EmotionTab.module.css
+++ b/Modi-frontend/src/components/HomePage/EmotionTab/EmotionTab.module.css
@@ -1,8 +1,10 @@
 .wrapper {
+  width: 100%;
   display: flex;
   gap: 8px;
   overflow-x: auto;
   scrollbar-width: thin;
+  -ms-overflow-style: none;
 }
 
 /*WebKit 브라우저 전용*/

--- a/Modi-frontend/src/components/HomePage/EmotionTab/EmotionTab.tsx
+++ b/Modi-frontend/src/components/HomePage/EmotionTab/EmotionTab.tsx
@@ -19,8 +19,6 @@ const DEFAULT_EMOTIONS = [
 export type Emotion = (typeof DEFAULT_EMOTIONS)[number];
 
 interface EmotionTabProps {
-  /* 필터링할 감정 리스트 */
-  emotions?: readonly Emotion[];
   /* 현재 선택된 감정 (null이면 전체) */
   selectedEmotion: Emotion | null;
   /* 감정 클릭 시 호출 */
@@ -30,20 +28,21 @@ interface EmotionTabProps {
 }
 
 export default function EmotionTab({
-  emotions = DEFAULT_EMOTIONS,
   selectedEmotion,
   onSelectEmotion,
   userCharacter,
 }: EmotionTabProps) {
   return (
     <div className={styles.wrapper}>
-      {emotions.map((emotion) => (
+      {DEFAULT_EMOTIONS.map((emotion) => (
         <EmotionChip
           key={emotion}
           label={emotion}
           type={userCharacter}
           selected={selectedEmotion === emotion}
-          onClick={() => onSelectEmotion(emotion)}
+          onClick={() =>
+            onSelectEmotion(selectedEmotion === emotion ? null : emotion)
+          }
         />
       ))}
     </div>

--- a/Modi-frontend/src/components/tag/EmotionChip/EmotionChip.module.css
+++ b/Modi-frontend/src/components/tag/EmotionChip/EmotionChip.module.css
@@ -1,13 +1,14 @@
 .chip {
   display: inline-flex;
-  height: 30px;
+  width: auto;
+  height: 23px;
   padding: 4px 12px;
   justify-content: center;
   align-items: center;
   gap: 10px;
   flex-shrink: 0;
   border: 1px solid;
-  border-radius: 15px;
+  border-radius: 30px;
 }
 
 .label {

--- a/Modi-frontend/src/pages/home/HomePage.module.css
+++ b/Modi-frontend/src/pages/home/HomePage.module.css
@@ -1,4 +1,5 @@
 .home_wrapper {
+  position: relative;
   display: flex;
   justify-content: center;
   align-items: center;
@@ -50,4 +51,63 @@
   padding: 0 16px;
   margin-top: 48px;
   margin-bottom: 16px;
+}
+
+.content {
+  position: relative;
+  top: 80px;
+  width: 360px;
+  height: 580px;
+}
+
+.carousel {
+  position: relative;
+  display: flex;
+  justify-content: center;
+  align-items: flex-end;
+  gap: 0px;
+  overflow: hidden;
+  padding: 0 80px;
+  height: 338px;
+}
+
+.slot1 {
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%) rotate(-15deg) translateX(-190px)
+    translateY(-50px) scale(0.9);
+  transform-origin: bottom center;
+  z-index: 1;
+}
+
+/* 슬롯2: 중앙(현재) */
+.slot2 {
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%) rotate(0deg);
+  z-index: 2;
+}
+
+/* 슬롯3: 오른쪽 */
+.slot3 {
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%) rotate(15deg) translateX(190px) translateY(-50px)
+    scale(0.9);
+  transform-origin: bottom center;
+  z-index: 1;
+}
+
+/* 빈 슬롯: 프레임 크기만큼 자리만 차지 */
+.emptySlot {
+  width: 328px; /* PolaroidFrame 너비에 맞춰주세요 */
+  height: 360px; /* PolaroidFrame 높이에 맞춰주세요 */
+}
+
+.staticInfo {
+  position: relative;
+  display: flex;
+  justify-content: center;
+  gap: 160px;
+  padding: 0 16px;
 }

--- a/Modi-frontend/src/pages/home/HomePage.module.css
+++ b/Modi-frontend/src/pages/home/HomePage.module.css
@@ -18,8 +18,10 @@
 }
 
 .photoGrid {
+  position: relative;
+  top: -25px;
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+  grid-template-columns: repeat(3, 1fr);
   gap: 8px;
   padding: 16px;
 }

--- a/Modi-frontend/src/pages/home/HomePage.module.css
+++ b/Modi-frontend/src/pages/home/HomePage.module.css
@@ -53,6 +53,12 @@
   margin-bottom: 16px;
 }
 
+.emotionTab {
+  position: relative;
+  top: -15px;
+  left: 16px;
+}
+
 .content {
   position: relative;
   top: 80px;

--- a/Modi-frontend/src/pages/home/PhotoView.tsx
+++ b/Modi-frontend/src/pages/home/PhotoView.tsx
@@ -82,12 +82,13 @@ export default function PhotoView({ onSwitchView }: PhotoViewProps) {
       />
       <div className={pageStyles.content}>
         {/* 감정 탭 */}
-        <EmotionTab
-          emotions={emotionList}
-          selectedEmotion={selectedEmotion}
-          onSelectEmotion={setSelectedEmotion}
-          userCharacter={character!}
-        />
+        <div className={pageStyles.emotionTab}>
+          <EmotionTab
+            selectedEmotion={selectedEmotion}
+            onSelectEmotion={setSelectedEmotion}
+            userCharacter={character!}
+          />
+        </div>
 
         {/* 사진 그리드 */}
         <div className="pageStyles.photoGrid">

--- a/Modi-frontend/src/pages/home/PhotoView.tsx
+++ b/Modi-frontend/src/pages/home/PhotoView.tsx
@@ -91,7 +91,7 @@ export default function PhotoView({ onSwitchView }: PhotoViewProps) {
         </div>
 
         {/* 사진 그리드 */}
-        <div className="pageStyles.photoGrid">
+        <div className={pageStyles.photoGrid}>
           {filtered.map((d) => (
             <PhotoDiary
               key={d.id}

--- a/Modi-frontend/src/pages/home/PolaroidView.tsx
+++ b/Modi-frontend/src/pages/home/PolaroidView.tsx
@@ -7,11 +7,11 @@ import DateSelector, {
 } from "../../components/HomePage/DateSelect/DateSelector";
 import ButtonBar from "../../components/common/button/ButtonBar/PrimaryButton";
 import Modal from "../../components/common/Modal";
-import PolaroidDiary from "../../components/HomePage/Diary/Polaroid/PolaroidDiary";
-import { useCharacter } from "../../contexts/CharacterContext";
-import { allDiaries } from "../../data/diaries";
+import PolaroidFrame from "../../components/HomePage/Diary/Polaroid/PolaroidFrame";
 import EmotionCharacter from "../../components/HomePage/Diary/Polaroid/EmotionCharacter";
 import EmotionTagList from "../../components/HomePage/Diary/Polaroid/EmotionTagList";
+import { useCharacter } from "../../contexts/CharacterContext";
+import { allDiaries } from "../../data/diaries";
 
 interface PolaroidViewProps {
   onSwitchView: () => void;
@@ -28,6 +28,21 @@ export default function PolaroidView({ onSwitchView }: PolaroidViewProps) {
   const [viewDate, setViewDate] = useState(() => allDates.at(-1)!);
 
   const [isModalOpen, setIsModalOpen] = useState(false);
+
+  // 현재 인덱스
+  const currentIdx = allDates.indexOf(viewDate);
+  // 보여줄 날짜: 이전, 현재, 다음
+  const slots = [
+    currentIdx > 0
+      ? allDiaries.find((d) => d.date === allDates[currentIdx - 1])!
+      : null,
+    allDiaries.find((d) => d.date === viewDate)!,
+    currentIdx < allDates.length - 1
+      ? allDiaries.find((d) => d.date === allDates[currentIdx + 1])!
+      : null,
+  ];
+
+  const currentDiary = allDiaries.find((d) => d.date === viewDate)!;
 
   const handlePrev = () => {
     const idx = allDates.indexOf(viewDate);
@@ -52,21 +67,29 @@ export default function PolaroidView({ onSwitchView }: PolaroidViewProps) {
         }}
         onSwitchView={onSwitchView}
       />
+      {/* ← 프레임만 캐러셀로 감싸기 */}
       <div className={pageStyles.content}>
-        {allDiaries
-          .filter((d) => d.date === viewDate)
-          .map((d) => (
-            <React.Fragment key={d.id}>
-              <PolaroidDiary
-                date={d.date}
-                photoUrl={d.photoUrl}
-                emotion={d.emotion}
-                content={d.summary}
-                tags={d.tags ?? []}
-                clicked={false}
-              />
-            </React.Fragment>
+        <div className={pageStyles.carousel}>
+          {slots.map((d, i) => (
+            <div key={i} className={pageStyles[`slot${i + 1}`]}>
+              {d ? (
+                <PolaroidFrame
+                  photoUrl={d.photoUrl}
+                  date={d.date}
+                  emotion={d.emotion}
+                  summary={d.summary}
+                />
+              ) : (
+                <div className={pageStyles.emptySlot} />
+              )}
+            </div>
           ))}
+        </div>
+        {/* ← 이 아래는 “항상 현재 일기” 것만 고정으로 보여줍니다 */}
+        <div className={pageStyles.staticInfo}>
+          <EmotionCharacter emotion={currentDiary.emotion} />
+          <EmotionTagList tags={currentDiary.tags ?? []} />
+        </div>
       </div>
 
       {/* 날짜 선택 모달 */}


### PR DESCRIPTION
## Related issue 🛠

closed #<issue_number>

어떤 변경사항이 있었나요?

- [ ] 🐞 BugFix Something isn't working
- [ ] 🎨 Design Markup & styling
- [ ] 📃 Docs Documentation writing and editing ([README.md](http://readme.md/), etc.)
- [x] ✨ Feature Feature
- [ ] 🔨 Refactor Code refactoring
- [ ] ⚙️ Setting Development environment setup
- [ ] ✅ Test Test related (Junit, etc.)

## CheckPoint ✅

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] PR 컨벤션에 맞게 작성했습니다. (필수)
- [x] merge할 브랜치의 위치를 확인해 주세요(main❌/develop⭕) (필수)
- [x] Approve된 PR은 assigner가 머지하고, 수정 요청이 온 경우 수정 후 다시 push를 합니다. (필수)
- [ ] BugFix의 경우, 버그의 원인을 파악하였습니다. (선택)

## Work Description ✏️

- PolaroidView: 이전·다음 일기 컴포넌트 고정 표시 및 레이아웃 개선

- EmotionTab: 감정칩 토글 기능 및 전체 감정 표시 기능 개선

- PhotoView: 사진 그리드 뷰 3열 고정 및 레이아웃 수정

## Uncompleted Tasks 😅

- [ ] 선택한 감정의 일기가 없을 때 캐릭터+글자 컴포넌트 렌더링
- [ ] 날짜 선택 모달 오류 해결
- [ ] Header 추가
- [ ] 다른 화면 이동 후 이전 화면 상태 유지

## To Reviewers 📢
