### PR TITLE
fix: home 바텀시트 안보이는 문제 해결

### DIFF
--- a/Modi-frontend/src/components/HomePage/DateSelect/DateSelector.tsx
+++ b/Modi-frontend/src/components/HomePage/DateSelect/DateSelector.tsx
@@ -42,6 +42,8 @@ const DateSelector: React.FC<Props> = ({
     [items]
   );
 
+  const hasMounted = useRef(false);
+
   const months = useMemo(
     () =>
       Array.from(
@@ -102,6 +104,11 @@ const DateSelector: React.FC<Props> = ({
 
   // state가 바뀔 때 마다 onChange 호출
   useEffect(() => {
+    if (!hasMounted.current) {
+      hasMounted.current = true;
+      return;
+    }
+
     if (viewType === "polaroid") onChange(`${year}-${month}-${day}`);
     else onChange(`${year}-${month}`);
   }, [year, month, day]);

--- a/Modi-frontend/src/pages/home/PolaroidView.tsx
+++ b/Modi-frontend/src/pages/home/PolaroidView.tsx
@@ -1,6 +1,5 @@
-import React, { useState, useMemo } from "react";
+import { useState, useMemo, useEffect, useRef } from "react";
 import pageStyles from "./HomePage.module.css";
-import { useNavigate } from "react-router-dom";
 import HomeHeader from "../../components/HomePage/HomeHeader/HomeHeader";
 import DateSelector, {
   DiaryItem,
@@ -18,7 +17,8 @@ interface PolaroidViewProps {
 }
 
 export default function PolaroidView({ onSwitchView }: PolaroidViewProps) {
-  const navigate = useNavigate();
+  const [isSheetOpen, setIsSheetOpen] = useState(false);
+  const hasOpened = useRef(false);
   const { character } = useCharacter();
 
   const allDates = useMemo(
@@ -26,8 +26,6 @@ export default function PolaroidView({ onSwitchView }: PolaroidViewProps) {
     []
   );
   const [viewDate, setViewDate] = useState(() => allDates.at(-1)!);
-
-  const [isSheetOpen, setIsSheetOpen] = useState(false);
 
   // 현재 인덱스
   const currentIdx = allDates.indexOf(viewDate);
@@ -51,6 +49,23 @@ export default function PolaroidView({ onSwitchView }: PolaroidViewProps) {
   const handleNext = () => {
     const idx = allDates.indexOf(viewDate);
     if (idx < allDates.length - 1) setViewDate(allDates[idx + 1]);
+  };
+
+  // 모달 열릴 때마다 초기화
+  useEffect(() => {
+    if (isSheetOpen) {
+      hasOpened.current = false;
+    }
+  }, [isSheetOpen]);
+
+  const handleChange = (newDate: string) => {
+    setViewDate(newDate);
+
+    if (hasOpened.current) {
+      setIsSheetOpen(false); // 두 번째 이후부터 닫힘
+    } else {
+      hasOpened.current = true; // 첫 호출은 무시
+    }
   };
 
   return (
@@ -105,10 +120,7 @@ export default function PolaroidView({ onSwitchView }: PolaroidViewProps) {
             viewType="polaroid"
             items={allDates.map((d) => ({ date: d }))}
             initialDate={viewDate}
-            onChange={(newDate) => {
-              setViewDate(newDate);
-              setIsSheetOpen(false);
-            }}
+            onChange={handleChange}
             userCharacter={character!}
           />
         </div>


### PR DESCRIPTION
## Related issue 🛠

closed #<issue_number>
어떤 변경사항이 있었나요?

- [ ] 기능 추가 (Feature)
- [ ] 기능 제거 (Remove)
- [x] 버그 수정 (Bugfix)
- [ ] 리팩토링 (Refactor)
- [ ] 리뷰 반영 (Review Update)
- [ ] 디자인 수정 (Designfix)
- [ ] 문서 작성 및 수정 (Docs: README.md 등)
- [ ] 기능 추가 (Feature)
- [ ] 코드 리팩토링 (Refactor)
- [ ] 개발 환경 설정 (Setting)
- [ ] 테스트 관련 (Test: JUnit 등)

## CheckPoint ✅

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] PR 컨벤션에 맞게 작성했습니다. (필수)
- [x] merge할 브랜치의 위치를 확인해 주세요(main❌/개인작업브랜치⭕) (필수)
- [x] 버그 수정의 경우, 버그의 원인을 파악하였습니다. (선택)

## Work Description ✏️

- 홈에서 바텀시트 안보이는 문제 해결

## Uncompleted Tasks 😅

- [ ] Task1

## To Reviewers 📢
DateSelector 컴포넌트에서 onChange가 랜더링 될때 초기 실행되어서 바로 false가 되는 문제 발견
onChange()에 setIsSheetOpen(false)가 들어있었음 
그래서 hasMounted를 써서 첫 마운트 시 onChange 호출을 막고 확인을 누르면 false가 되도록 수정