### PR TITLE
Feat : 뒤로가기 버튼 / 알림 / 설정 페이지 라우팅 추가

### DIFF
--- a/Modi-frontend/src/pages/home/HomePage.tsx
+++ b/Modi-frontend/src/pages/home/HomePage.tsx
@@ -8,15 +8,20 @@ import PhotoView from "./PhotoView";
 import Header from "../../components/common/Header";
 import { allDiaries } from "../../data/diaries"; // 또는 상태 관리 데이터
 import EmptyDiaryView from "./EmptyDiaryView";
+import { useNavigate } from "react-router-dom";
 
 export default function HomePage() {
   const [viewType, setViewType] = useState<"photo" | "polaroid">("polaroid");
+  const navigate = useNavigate();
   return (
     <div className={style.home_wrapper}>
       <div className={style.home_container}>
         <Header
           left="/images/logo/Modi.svg"
           right="/icons/notification_O.svg"
+          RightClick={() => {
+            navigate("/notification");
+          }}
         />
 
         <main className={style.mainContent}>

--- a/Modi-frontend/src/pages/map/MapPage.module.css
+++ b/Modi-frontend/src/pages/map/MapPage.module.css
@@ -3,8 +3,8 @@
   flex-direction: column;
   width: 100vw;
   height: 100vh;
-  max-width: 360px;
-  max-height: 800px;
+  max-width: 400px;
+  max-height: auto;
   background-color: #f5f5f5;
 }
 

--- a/Modi-frontend/src/pages/map/MapPage.tsx
+++ b/Modi-frontend/src/pages/map/MapPage.tsx
@@ -128,8 +128,9 @@ const MapPage = () => {
             <div
               className={styles.map_container}
               style={{
+                maxWidth: "400px",
                 minHeight: "500px", // 최소 높이 증가
-                height: "calc(100vh - 200px)", // 뷰포트 높이에서 푸터 등 제외
+                height: "calc(100vh)", // 뷰포트 높이에서 푸터 등 제외
               }}
             >
               <KakaoMap

--- a/Modi-frontend/src/pages/mypage/MyPage.tsx
+++ b/Modi-frontend/src/pages/mypage/MyPage.tsx
@@ -7,6 +7,7 @@ import Footer from "../../components/common/Footer";
 import FavoriteView from "./FavoriteView";
 import StatsView from "./StatsView";
 import { allDiaries, Diary } from "../../data/diaries";
+import { useNavigate } from "react-router-dom";
 
 const TAB_LABELS = ["즐겨찾기", "월간 일기"] as const;
 type TabLabel = (typeof TAB_LABELS)[number];
@@ -14,7 +15,7 @@ type TabLabel = (typeof TAB_LABELS)[number];
 const MyPage = () => {
   const [selectedTab, setSelectedTab] = useState<TabLabel>("즐겨찾기");
   const [nickname, setNickname] = useState<string>("user123@email.com");
-
+  const navigate = useNavigate();
   useEffect(() => {
     const savedNickname = localStorage.getItem("nickname");
     if (savedNickname) {
@@ -29,6 +30,12 @@ const MyPage = () => {
           left="/icons/setting.svg"
           middle="마이페이지"
           right="/icons/notification_O.svg"
+          LeftClick={() => {
+            navigate("/setting");
+          }}
+          RightClick={() => {
+            navigate("/notification");
+          }}
         />
         <div className={style.fixedHeader}>
           <div className={style.content}>

--- a/Modi-frontend/src/pages/notification/NotificationPage.module.css
+++ b/Modi-frontend/src/pages/notification/NotificationPage.module.css
@@ -1,11 +1,15 @@
 .notification_page_wrapper {
   position: relative;
+
   overflow: hidden;
   background-image: url("/images/background/normal-bg.svg");
+  background-size: cover;
+  background-position: top center;
+  background-repeat: no-repeat;
   width: 100vw;
   height: 100vh;
-  max-width: 360px;
-  max-height: 800px;
+  max-width: 400px;
+  max-height: auto;
   display: flex;
   flex-direction: column;
   align-items: center;

--- a/Modi-frontend/src/pages/notification/NotificationPage.tsx
+++ b/Modi-frontend/src/pages/notification/NotificationPage.tsx
@@ -2,11 +2,20 @@ import React from "react";
 import Header from "../../components/common/Header";
 import styles from "./NotificationPage.module.css";
 import NotificationItem from "../../components/notification/NotificationItem";
+import { useNavigate } from "react-router-dom";
 
 const NotificationPage = () => {
+  const navigate = useNavigate();
+
   return (
     <div className={styles.notification_page_wrapper}>
-      <Header left="/icons/arrow_left.svg" middle="알림" />
+      <Header
+        left="/icons/arrow_left.svg"
+        middle="알림"
+        LeftClick={() => {
+          navigate(-1);
+        }}
+      />
       <div className={styles.notification_container}>
         <div className={styles.today_notification}>
           <span className={styles.today}>오늘</span>

--- a/Modi-frontend/src/pages/setting/Setting.tsx
+++ b/Modi-frontend/src/pages/setting/Setting.tsx
@@ -2,11 +2,14 @@ import React, { useState } from "react";
 import styles from "./Setting.module.css";
 import Header from "../../components/common/Header";
 import ToggleSwitch from "../../components/toggle/ToggleSwitch";
+import { useNavigate } from "react-router-dom";
 
 const Setting = () => {
   // 설정별 이벤트 처리
   //캐릭터 id 가져오기
   const [selectedCharacter, setSelectedCharacter] = useState<string>("");
+
+  const navigate = useNavigate();
 
   const handleNotificationClick = () => {
     // 알림 설정 이벤트
@@ -25,7 +28,13 @@ const Setting = () => {
 
   return (
     <div className={styles.setting_wrapper}>
-      <Header left="/icons/arrow_left.svg" middle="설정" />
+      <Header
+        left="/icons/arrow_left.svg"
+        middle="설정"
+        LeftClick={() => {
+          navigate("/mypage");
+        }}
+      />
       <div className={styles.setting_container}>
         <div className={styles.notification} onClick={handleNotificationClick}>
           <span>알림 설정</span>


### PR DESCRIPTION
## Related issue 🛠

closed #<issue_number>
어떤 변경사항이 있었나요?

- [x] 기능 추가 (Feature)
- [ ] 기능 제거 (Remove)
- [ ] 버그 수정 (Bugfix)
- [ ] 리팩토링 (Refactor)
- [ ] 리뷰 반영 (Review Update)
- [ ] 디자인 수정 (Designfix)
- [ ] 문서 작성 및 수정 (Docs: README.md 등)
- [x] 기능 추가 (Feature)
- [ ] 코드 리팩토링 (Refactor)
- [ ] 개발 환경 설정 (Setting)
- [ ] 테스트 관련 (Test: JUnit 등)

## CheckPoint ✅

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] PR 컨벤션에 맞게 작성했습니다. (필수)
- [ ] merge할 브랜치의 위치를 확인해 주세요(main❌/개인작업브랜치⭕) (필수)
- [ ] 버그 수정의 경우, 버그의 원인을 파악하였습니다. (선택)

## Work Description ✏️

- 아직 라우팅이 안됐던 버튼들 찾아서 네비게이션 해두었습니다 ~
- 알림 페이지는 홈화면이랑 마이페이지 둘 다 있어서 navigate(-1); 로 이전 페이지로 돌아가게 해두었으니 참고하시면 될 것 같아요 !

## Uncompleted Tasks 😅

- [ ] None

## To Reviewers 📢
