### PR TITLE
Fix: 내 위치 확인 시 Geolocation API 에러 무시

### DIFF
--- a/Modi-frontend/src/components/map/Geolocation.module.css
+++ b/Modi-frontend/src/components/map/Geolocation.module.css
@@ -87,8 +87,3 @@
   transform: translateY(0);
   box-shadow: 0 2px 4px rgba(255, 107, 107, 0.3);
 }
-
-.info_window {
-  padding: 5px;
-  font-size: 12px;
-}

--- a/Modi-frontend/src/components/map/Geolocation.tsx
+++ b/Modi-frontend/src/components/map/Geolocation.tsx
@@ -31,7 +31,12 @@ const Geolocation: React.FC<GeolocationProps> = ({ map }) => {
 
   // 현재 위치 가져오기
   const getCurrentPosition = () => {
-    console.log("getCurrentPosition 호출됨");
+    console.log("=== getCurrentPosition 호출됨 ===");
+    console.log("navigator.geolocation 지원 여부:", !!navigator.geolocation);
+    console.log("mapRef.current 존재 여부:", !!mapRef.current);
+    console.log("현재 URL:", window.location.href);
+    console.log("HTTPS 여부:", window.location.protocol === "https:");
+
     if (!mapRef.current) {
       alert("지도가 로드되지 않았습니다. 잠시 후 다시 시도해주세요.");
       return;
@@ -39,6 +44,27 @@ const Geolocation: React.FC<GeolocationProps> = ({ map }) => {
 
     setIsLoading(true);
     setPermissionDenied(false);
+
+    // 권한 상태 확인 (새로운 브라우저에서 지원)
+    if ("permissions" in navigator) {
+      navigator.permissions
+        .query({ name: "geolocation" })
+        .then((result) => {
+          console.log("위치 권한 상태:", result.state);
+          // 권한 상태를 localStorage에 저장
+          localStorage.setItem("geolocation_permission", result.state);
+
+          if (result.state === "denied") {
+            console.warn("위치 권한이 거부됨");
+            setPermissionDenied(true);
+            setIsLoading(false);
+            return;
+          }
+        })
+        .catch((error) => {
+          console.warn("권한 상태 확인 실패:", error);
+        });
+    }
 
     // 브라우저의 Geolocation API 사용
     if (navigator.geolocation) {
@@ -70,7 +96,8 @@ const Geolocation: React.FC<GeolocationProps> = ({ map }) => {
 
             // 인포윈도우 생성 (선택사항)
             const infowindow = new kakao.maps.InfoWindow({
-              content: "<div className={styles.info_window}>현재 위치</div>",
+              content:
+                "<div style='padding: 8px 45px 8px 45px; font-size: 15px; font-family: var(--font-nanum-square, 'NanumSquareRound');'>현재 위치</div>",
             });
             infowindow.open(mapRef.current, markerRef.current);
 
@@ -87,29 +114,51 @@ const Geolocation: React.FC<GeolocationProps> = ({ map }) => {
         },
         // 에러 콜백
         (error) => {
+          console.log("=== Geolocation 에러 발생 ===");
+          console.log("에러 코드:", error.code);
+          console.log("에러 메시지:", error.message);
+          console.log("전체 에러 객체:", error);
+
+          // HTTP 환경에서 권한이 허용되었는데도 에러가 발생하는 경우 처리
+          const isHttpEnvironment = window.location.protocol !== "https:";
+          const isPermissionGranted =
+            localStorage.getItem("geolocation_permission") === "granted";
+
+          if (
+            isHttpEnvironment &&
+            error.code === error.PERMISSION_DENIED &&
+            isPermissionGranted
+          ) {
+            console.log(
+              "HTTP 환경에서 권한 허용 후 에러 발생 - 무시하고 계속 진행"
+            );
+            return; // 에러를 무시하고 계속 진행
+          }
+
           setIsLoading(false);
           let errorMessage = "위치 정보를 가져오는데 실패했습니다.";
 
           switch (error.code) {
             case error.PERMISSION_DENIED:
-              errorMessage =
-                "위치 정보 접근이 거부되었습니다.\n\n브라우저 설정에서 위치 정보 접근을 허용해주세요:\n\nChrome: 설정 → 개인정보 보호 및 보안 → 사이트 설정 → 위치 정보 → 허용\nSafari: 환경설정 → 웹사이트 → 위치 서비스 → 허용\nFirefox: 설정 → 개인정보 보호 및 보안 → 권한 → 위치 정보 → 허용";
+              errorMessage = "위치 정보 접근이 거부되었습니다.";
               setPermissionDenied(true);
-              // 권한 거부 상태를 localStorage에 저장
               localStorage.setItem("geolocation_denied", "true");
+              console.warn("사용자가 위치 권한을 거부했습니다.");
               break;
             case error.POSITION_UNAVAILABLE:
               errorMessage = "위치 정보를 사용할 수 없습니다.";
+              console.warn("위치 정보를 사용할 수 없습니다.");
               break;
             case error.TIMEOUT:
               errorMessage = "위치 정보 요청 시간이 초과되었습니다.";
+              console.warn("위치 정보 요청 시간이 초과되었습니다.");
               break;
             default:
               errorMessage = "알 수 없는 오류가 발생했습니다.";
+              console.warn("알 수 없는 Geolocation 오류:", error);
               break;
           }
 
-          alert(errorMessage);
           console.error("Geolocation error:", error);
         },
         // 옵션
@@ -122,6 +171,18 @@ const Geolocation: React.FC<GeolocationProps> = ({ map }) => {
     } else {
       setIsLoading(false);
       alert("이 브라우저에서는 위치 정보를 지원하지 않습니다.");
+    }
+  };
+
+  // 권한 상태 확인
+  const checkPermissionStatus = () => {
+    if (navigator.permissions && navigator.permissions.query) {
+      navigator.permissions.query({ name: "geolocation" }).then((result) => {
+        console.log("위치 권한 상태:", result.state);
+        if (result.state === "denied") {
+          setPermissionDenied(true);
+        }
+      });
     }
   };
 


### PR DESCRIPTION
## Related issue 🛠

closed #<issue_number>
어떤 변경사항이 있었나요?

- [ ] 기능 추가 (Feature)
- [ ] 기능 제거 (Remove)
- [x] 버그 수정 (Bugfix)
- [ ] 리팩토링 (Refactor)
- [ ] 리뷰 반영 (Review Update)
- [ ] 디자인 수정 (Designfix)
- [ ] 문서 작성 및 수정 (Docs: README.md 등)
- [ ] 기능 추가 (Feature)
- [ ] 코드 리팩토링 (Refactor)
- [ ] 개발 환경 설정 (Setting)
- [ ] 테스트 관련 (Test: JUnit 등)

## CheckPoint ✅

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] PR 컨벤션에 맞게 작성했습니다. (필수)
- [x] merge할 브랜치의 위치를 확인해 주세요(main❌/개인작업브랜치⭕) (필수)
- [ ] 버그 수정의 경우, 버그의 원인을 파악하였습니다. (선택)

## Work Description ✏️

- 내 위치 확인 시 Geolocation API 에러 무시하도록 했습니다! 

<img width="736" height="269" alt="image" src="https://github.com/user-attachments/assets/2b9d2721-2c82-4891-9bd4-038a32e43dd9" />

- 사진 보시면 위치 권한 상태: granted 임에도 에러가 잡히는데요, 이는 HTTPS 환경이 아닌 HTTP 환경이라서 Geolocation API가 권한을 허용해도 에러를 발생시키는 경우가 있다고 합니다! 그래서 에러 메시지 출력이 안되게 수정했습니다! 
- 또, 위치 권한 상태를 localStorage에 저장해서 사용할 수 있도록 구현했습니다 ~
<img width="931" height="269" alt="image" src="https://github.com/user-attachments/assets/e5716e9d-c640-4a40-8255-6f63228c5b94" />

## Uncompleted Tasks 😅

- [ ] HTTPS 환경에서도 에러가 발생하는지 확인해볼 것

## To Reviewers 📢
