### PR TITLE
Feat, Design (mypage):즐겨찾기 조회, 월별 통계 조회 api 연결 및 css 개선

### DIFF
--- a/Modi-frontend/src/apis/apiClient.ts
+++ b/Modi-frontend/src/apis/apiClient.ts
@@ -1,7 +1,7 @@
 import axios from "axios";
 
 const apiClient = axios.create({
-  baseURL: import.meta.env.VITE_API_URL,
+  baseURL: "/api",
   headers: {
     "Content-Type": "application/json",
   },

--- a/Modi-frontend/src/apis/favorites.ts
+++ b/Modi-frontend/src/apis/favorites.ts
@@ -7,9 +7,9 @@ export interface FavoriteItem {
 }
 
 // 즐겨찾기 목록 불러오기
-export const getFavorites = () =>
-  apiClient.get<FavoriteItem[]>("/diaries/favorites");
-
+export const getFavorites = () => {
+  return apiClient.get<FavoriteItem[]>("/diaries/favorites");
+};
 // 즐겨찾기 추가, 해제 (상세 페이지에서 누를 때)
 export const updateFavorite = (diaryId: number, favorite: boolean) =>
   apiClient.post(`/diaries/${diaryId}/favorite?favorite=${favorite}`);

--- a/Modi-frontend/src/apis/favorites.ts
+++ b/Modi-frontend/src/apis/favorites.ts
@@ -8,8 +8,8 @@ export interface FavoriteItem {
 
 // 즐겨찾기 목록 불러오기
 export const getFavorites = () =>
-  apiClient.get<FavoriteItem[]>("/api/diaries/favorites");
+  apiClient.get<FavoriteItem[]>("/diaries/favorites");
 
 // 즐겨찾기 추가, 해제 (상세 페이지에서 누를 때)
 export const updateFavorite = (diaryId: number, favorite: boolean) =>
-  apiClient.post(`/api/diaries/${diaryId}/favorite?favorite=${favorite}`);
+  apiClient.post(`/diaries/${diaryId}/favorite?favorite=${favorite}`);

--- a/Modi-frontend/src/apis/stats.ts
+++ b/Modi-frontend/src/apis/stats.ts
@@ -1,0 +1,18 @@
+import apiClient from "./apiClient";
+
+export interface StatisticsItem {
+  name: string;
+  count: number;
+}
+
+export interface StatisticsResponse {
+  totalCount: number;
+  topEmotions: StatisticsItem[];
+  topTones: StatisticsItem[];
+  topLocations: StatisticsItem[];
+}
+
+export const getStatistics = (year: string, month: string) =>
+  apiClient.get<StatisticsResponse>(
+    `/diaries/statistics?year=${year}&month=${month}`
+  );

--- a/Modi-frontend/src/components/MyPage/Stats/ChartItem/EmotionCircle.module.css
+++ b/Modi-frontend/src/components/MyPage/Stats/ChartItem/EmotionCircle.module.css
@@ -1,6 +1,6 @@
 .container {
   display: flex;
-  gap: 0px;
+  gap: 22px;
   justify-content: center;
   align-items: flex-end;
 }

--- a/Modi-frontend/src/components/MyPage/Stats/ChartItem/StyleStatsBarList.tsx
+++ b/Modi-frontend/src/components/MyPage/Stats/ChartItem/StyleStatsBarList.tsx
@@ -5,27 +5,29 @@ import { useCharacter } from "../../../../contexts/CharacterContext";
 
 const MAX_BAR_HEIGHT = 70;
 
+interface StyleDataItem {
+  label: string;
+  value: number;
+  icon?: string;
+}
+
 interface StyleBarListProps {
+  data: StyleDataItem[];
   onMaxLabelChange?: (label: string) => void;
 }
 
-export default function StyleBarList({ onMaxLabelChange }: StyleBarListProps) {
+export default function StyleBarList({
+  data,
+  onMaxLabelChange,
+}: StyleBarListProps) {
   const { character } = useCharacter();
-
-  if (!character) return null;
+  if (!character || data.length === 0) return null;
 
   const iconPath = `/images/character-statsbar/${character}/${character}_head.svg`;
   const coloredIcon = `/images/character-statsbar/${character}/${character}_head_color.svg`;
 
-  const styleData = [
-    { label: "즐거움", value: 15, icon: iconPath },
-    { label: "고민", value: 13, icon: iconPath },
-    { label: "슬픔", value: 5, icon: iconPath },
-    { label: "화남", value: 2, icon: iconPath },
-  ];
-
-  const max = Math.max(...styleData.map((d) => d.value));
-  const maxLabel = styleData.find((d) => d.value === max)?.label;
+  const max = Math.max(...data.map((d) => d.value));
+  const maxLabel = data.find((d) => d.value === max)?.label;
 
   // maxLabel이 변경되면 부모에 알림
   useEffect(() => {
@@ -41,7 +43,7 @@ export default function StyleBarList({ onMaxLabelChange }: StyleBarListProps) {
     zuni: "#93D1E0",
   };
 
-  const normalized = styleData
+  const normalized = [...data]
     .sort((a, b) => b.value - a.value) // 내림차순 정렬
     .map((d) => ({
       ...d,

--- a/Modi-frontend/src/components/MyPage/Stats/ChartItem/VisitStatsBarList.tsx
+++ b/Modi-frontend/src/components/MyPage/Stats/ChartItem/VisitStatsBarList.tsx
@@ -6,28 +6,23 @@ import { getVisitStatsByMonth } from "../../../../utils/getVisitStatsByMonth";
 
 const MAX_BAR_HEIGHT = 70;
 
-interface StyleBarListProps {
+interface VisitStatsBarListProps {
+  data: { label: string; value: number }[];
   onMaxLabelChange?: (label: string) => void;
 }
 
 export default function VisitStatsBarList({
+  data,
   onMaxLabelChange,
-}: StyleBarListProps) {
+}: VisitStatsBarListProps) {
   const { character } = useCharacter();
-  const now = new Date();
-  const ym = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(
-    2,
-    "0"
-  )}`;
-  const styleData = getVisitStatsByMonth(ym);
-
-  if (!character || styleData.length === 0) return null;
+  if (!character || data.length === 0) return null;
 
   const iconPath = `/images/character-statsbar/${character}/${character}_head.svg`;
   const coloredIcon = `/images/character-statsbar/${character}/${character}_head_color.svg`;
 
-  const max = Math.max(...styleData.map((d) => d.value));
-  const maxLabel = styleData.find((d) => d.value === max)?.label;
+  const max = Math.max(...data.map((d) => d.value));
+  const maxLabel = data.find((d) => d.value === max)?.label;
 
   // maxLabel이 변경되면 부모에 알림
   useEffect(() => {
@@ -43,7 +38,7 @@ export default function VisitStatsBarList({
     zuni: "#93D1E0",
   };
 
-  const normalized = [...styleData]
+  const normalized = [...data]
     .sort((a, b) => b.value - a.value) // 내림차순 정렬
     .map((d) => ({
       ...d,

--- a/Modi-frontend/src/components/MyPage/Stats/ChartItem/VisitStatsBarList.tsx
+++ b/Modi-frontend/src/components/MyPage/Stats/ChartItem/VisitStatsBarList.tsx
@@ -2,6 +2,7 @@ import React, { useEffect } from "react";
 import StyleBar from "./StyleStatsBar";
 import style from "./StyleStatsBar.module.css";
 import { useCharacter } from "../../../../contexts/CharacterContext";
+import { getVisitStatsByMonth } from "../../../../utils/getVisitStatsByMonth";
 
 const MAX_BAR_HEIGHT = 70;
 
@@ -13,18 +14,18 @@ export default function VisitStatsBarList({
   onMaxLabelChange,
 }: StyleBarListProps) {
   const { character } = useCharacter();
+  const now = new Date();
+  const ym = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(
+    2,
+    "0"
+  )}`;
+  const styleData = getVisitStatsByMonth(ym);
 
-  if (!character) return null;
+  if (!character || styleData.length === 0) return null;
 
   const iconPath = `/images/character-statsbar/${character}/${character}_head.svg`;
   const coloredIcon = `/images/character-statsbar/${character}/${character}_head_color.svg`;
 
-  const styleData = [
-    { label: "영통동", value: 15, icon: iconPath },
-    { label: "경희대", value: 7, icon: iconPath },
-    { label: "서천동", value: 5, icon: iconPath },
-    { label: "행궁동", value: 2, icon: iconPath },
-  ];
   const max = Math.max(...styleData.map((d) => d.value));
   const maxLabel = styleData.find((d) => d.value === max)?.label;
 
@@ -42,7 +43,7 @@ export default function VisitStatsBarList({
     zuni: "#93D1E0",
   };
 
-  const normalized = styleData
+  const normalized = [...styleData]
     .sort((a, b) => b.value - a.value) // 내림차순 정렬
     .map((d) => ({
       ...d,

--- a/Modi-frontend/src/components/MyPage/Stats/StatsCard/EmotionStatsCard.tsx
+++ b/Modi-frontend/src/components/MyPage/Stats/StatsCard/EmotionStatsCard.tsx
@@ -2,24 +2,34 @@ import EmotionCircleList from "../ChartItem/EmotionCircleList";
 import styles from "./StatsCard.module.css";
 import { useCharacter } from "../../../../contexts/CharacterContext";
 
-export default function EmotionStatsCard() {
-  const { character } = useCharacter();
+interface EmotionStatsCardProps {
+  data: {
+    label: string;
+    value: number;
+  }[];
+  month: string;
+}
 
-  const data = [
-    { label: "기쁨", value: 15 },
-    { label: "슬픔", value: 7 },
-    { label: "사랑", value: 5 },
-    { label: "놀람", value: 2 },
-  ];
+export default function EmotionStatsCard({
+  data,
+  month,
+}: EmotionStatsCardProps) {
+  const { character } = useCharacter();
   if (!character) return null;
   const maxValue = Math.max(...data.map((item) => item.value));
   const maxEmotion = data.find((item) => item.value === maxValue)?.label;
 
-  const emotionKeyMap: { [label: string]: string } = {
-    기쁨: "happy",
-    슬픔: "sad",
-    사랑: "love",
-    놀람: "surprised",
+  const emotionKeyMap: Record<string, string> = {
+    happy: "기쁨",
+    surprised: "놀람",
+    normal: "보통",
+    nervous: "떨림",
+    love: "사랑",
+    excited: "신남",
+    sick: "아픔",
+    sad: "슬픔",
+    bored: "지루함",
+    angry: "화남",
   };
 
   function getEmotionIconPath(
@@ -42,7 +52,9 @@ export default function EmotionStatsCard() {
 
   return (
     <div className={styles.card}>
-      <h3 className={styles.title}>6월은 {maxEmotion}을 가장 많이 느꼈어요</h3>
+      <h3 className={styles.title}>
+        {month.split("-")[1]}월은 {maxEmotion}을 가장 많이 느꼈어요
+      </h3>
       <EmotionCircleList data={sortedData} />
     </div>
   );

--- a/Modi-frontend/src/components/MyPage/Stats/StatsCard/EmotionStatsCard.tsx
+++ b/Modi-frontend/src/components/MyPage/Stats/StatsCard/EmotionStatsCard.tsx
@@ -18,8 +18,7 @@ export default function EmotionStatsCard({
   if (!character) return null;
   const maxValue = Math.max(...data.map((item) => item.value));
   const maxEmotion = data.find((item) => item.value === maxValue)?.label;
-
-  const emotionKeyMap: Record<string, string> = {
+  const emotionTextMap: Record<string, string> = {
     happy: "기쁨",
     surprised: "놀람",
     normal: "보통",
@@ -31,29 +30,49 @@ export default function EmotionStatsCard({
     bored: "지루함",
     angry: "화남",
   };
-
+  const emotionTextToKeyMap: Record<string, string> = {
+    기쁨: "happy",
+    놀람: "surprised",
+    보통: "normal",
+    떨림: "nervous",
+    사랑: "love",
+    신남: "excited",
+    아픔: "sick",
+    슬픔: "sad",
+    지루함: "bored",
+    화남: "angry",
+  };
   function getEmotionIconPath(
     character: string,
     emotionLabel: string,
     isMax: boolean
   ): string {
-    const key = emotionKeyMap[emotionLabel];
+    const key = emotionTextToKeyMap[emotionLabel];
     const prefix = isMax ? "clicked_" : "";
     return `/emotion_tag/${character}/${prefix}${character}-${key}.svg`;
   }
 
   if (!character) return null;
 
-  const enrichedData = data.map((item) => ({
-    ...item,
-    icon: getEmotionIconPath(character, item.label, item.value === maxValue),
-  }));
+  const enrichedData = data.map((item) => {
+    const iconPath = getEmotionIconPath(
+      character,
+      item.label,
+      item.value === maxValue
+    );
+    console.log("[디버깅] 감정:", item.label, "| 아이콘 경로:", iconPath);
+    return {
+      ...item,
+      icon: iconPath,
+    };
+  });
   const sortedData = [...enrichedData].sort((a, b) => b.value - a.value);
 
   return (
     <div className={styles.card}>
       <h3 className={styles.title}>
-        {month.split("-")[1]}월은 {maxEmotion}을 가장 많이 느꼈어요
+        {month.split("-")[1]}월은 {emotionTextMap[maxEmotion ?? ""]}을 가장 많이
+        느꼈어요
       </h3>
       <EmotionCircleList data={sortedData} />
     </div>

--- a/Modi-frontend/src/components/MyPage/Stats/StatsCard/StatsCard.module.css
+++ b/Modi-frontend/src/components/MyPage/Stats/StatsCard/StatsCard.module.css
@@ -10,6 +10,7 @@
 
   position: relative;
   right: 10px;
+  width: 290px;
 
   flex-shrink: 0;
 }

--- a/Modi-frontend/src/components/MyPage/Stats/StatsCard/StyleStats.tsx
+++ b/Modi-frontend/src/components/MyPage/Stats/StatsCard/StyleStats.tsx
@@ -1,16 +1,24 @@
-import { useState } from "react";
+import { useState, useMemo } from "react";
 import styles from "./StatsCard.module.css";
 import StyleStatsBarList from "../ChartItem/StyleStatsBarList";
+import { getToneStatsByMonth } from "../../../../utils/getToneStatsByMonths";
 
-export default function StyleStatsCard() {
+interface Props {
+  month: string; // "2025-07" 형태
+}
+
+export default function StyleStatsCard({ month }: Props) {
   const [maxLabel, setMaxLabel] = useState<string | null>(null);
+
+  // ✅ 해당 월 데이터 필터링
+  const toneData = useMemo(() => getToneStatsByMonth(month), [month]);
 
   return (
     <div className={styles.card}>
       <h3 className={styles.title}>
         {maxLabel} 언어 스타일을 가장 많이 사용했어요
       </h3>
-      <StyleStatsBarList onMaxLabelChange={setMaxLabel} />
+      <StyleStatsBarList data={toneData} onMaxLabelChange={setMaxLabel} />
     </div>
   );
 }

--- a/Modi-frontend/src/components/MyPage/Stats/StatsCard/StyleStats.tsx
+++ b/Modi-frontend/src/components/MyPage/Stats/StatsCard/StyleStats.tsx
@@ -1,24 +1,20 @@
-import { useState, useMemo } from "react";
+import { useState } from "react";
 import styles from "./StatsCard.module.css";
 import StyleStatsBarList from "../ChartItem/StyleStatsBarList";
-import { getToneStatsByMonth } from "../../../../utils/getToneStatsByMonths";
 
-interface Props {
-  month: string; // "2025-07" 형태
-}
-
-export default function StyleStatsCard({ month }: Props) {
+export default function StyleStatsCard({
+  data,
+}: {
+  data: { label: string; value: number }[];
+}) {
   const [maxLabel, setMaxLabel] = useState<string | null>(null);
-
-  // ✅ 해당 월 데이터 필터링
-  const toneData = useMemo(() => getToneStatsByMonth(month), [month]);
 
   return (
     <div className={styles.card}>
       <h3 className={styles.title}>
         {maxLabel} 언어 스타일을 가장 많이 사용했어요
       </h3>
-      <StyleStatsBarList data={toneData} onMaxLabelChange={setMaxLabel} />
+      <StyleStatsBarList data={data} onMaxLabelChange={setMaxLabel} />
     </div>
   );
 }

--- a/Modi-frontend/src/components/MyPage/Stats/StatsCard/VisitStats.tsx
+++ b/Modi-frontend/src/components/MyPage/Stats/StatsCard/VisitStats.tsx
@@ -2,7 +2,11 @@ import { useState } from "react";
 import styles from "./StatsCard.module.css";
 import VisitStatsBarList from "../ChartItem/VisitStatsBarList";
 
-export default function VisitStatsCard() {
+interface VisitStatsCardProps {
+  data: { label: string; value: number }[];
+}
+
+export default function VisitStatsCard({ data }: VisitStatsCardProps) {
   const [maxLabel, setMaxLabel] = useState<string | null>(null);
 
   return (
@@ -10,7 +14,7 @@ export default function VisitStatsCard() {
       <h3 className={styles.title}>
         한달 간 {maxLabel}을 가장 많이 방문했어요
       </h3>
-      <VisitStatsBarList onMaxLabelChange={setMaxLabel} />
+      <VisitStatsBarList data={data} onMaxLabelChange={setMaxLabel} />
     </div>
   );
 }

--- a/Modi-frontend/src/components/MyPage/Stats/StatsCard/VisitStats.tsx
+++ b/Modi-frontend/src/components/MyPage/Stats/StatsCard/VisitStats.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import styles from "./StatsCard.module.css";
 import VisitStatsBarList from "../ChartItem/VisitStatsBarList";
 
-export default function StyleStatsCard() {
+export default function VisitStatsCard() {
   const [maxLabel, setMaxLabel] = useState<string | null>(null);
 
   return (

--- a/Modi-frontend/src/pages/mypage/FavoriteView.tsx
+++ b/Modi-frontend/src/pages/mypage/FavoriteView.tsx
@@ -1,14 +1,35 @@
-import React from "react";
-import { allDiaries, Diary } from "../../data/diaries";
+import React, { useState, useEffect } from "react";
+import { FavoriteItem, getFavorites } from "../../apis/favorites";
 import FavoriteDiary from "../../components/MyPage/Favorite/FavoriteDiary";
 import styles from "./MyPage.module.css";
 
 export default function FavoriteView() {
-  const favorites: Diary[] = allDiaries;
+  const [favorites, setFavorites] = useState<FavoriteItem[]>([]);
+
+  useEffect(() => {
+    const fetchFavorites = async () => {
+      try {
+        const res = await getFavorites();
+        setFavorites(res.data); // API 응답 데이터 저장
+      } catch (err) {
+        console.error("❌ 즐겨찾기 불러오기 실패:", err);
+      }
+    };
+
+    fetchFavorites();
+  }, []);
+
   return (
     <div className={styles.photoGrid}>
       {favorites.map((d) => (
-        <FavoriteDiary key={d.id} {...d} clicked={false} />
+        <FavoriteDiary
+          key={d.id}
+          id={d.id}
+          photoUrl={d.thumbnailUrl}
+          date={d.date}
+          emotion={""}
+          clicked={false}
+        />
       ))}
     </div>
   );

--- a/Modi-frontend/src/pages/mypage/MyPage.module.css
+++ b/Modi-frontend/src/pages/mypage/MyPage.module.css
@@ -31,7 +31,7 @@
   width: 400px;
   height: auto;
   position: absolute;
-  left: 52px;
+  left: 38px;
   top: 0px;
   flex-shrink: 0;
   z-index: 10;

--- a/Modi-frontend/src/pages/mypage/StatsView.tsx
+++ b/Modi-frontend/src/pages/mypage/StatsView.tsx
@@ -1,10 +1,11 @@
-import React, { useState, useMemo } from "react";
+import React, { useState, useMemo, useEffect } from "react";
 import { allDiaries, Diary } from "../../data/diaries";
 import StatsDateSelect from "../../components/MyPage/Stats/StatsDateSelect";
 import styles from "./MyPage.module.css";
 import EmotionStatsCard from "../../components/MyPage/Stats/StatsCard/EmotionStatsCard";
 import StyleStats from "../../components/MyPage/Stats/StatsCard/StyleStats";
 import VisitStats from "../../components/MyPage/Stats/StatsCard/VisitStats";
+import { mockDiaries } from "../../apis/diaryInfo";
 
 type Emotion = Diary["emotion"];
 
@@ -35,6 +36,21 @@ export default function StatsView() {
     return counts;
   }, [monthDiaries]);
 
+  const [stats, setStats] = useState<StatsResponse | null>(null);
+
+  useEffect(() => {
+    const fetchStats = async () => {
+      const [y, m] = month.split("-"); // "2025-07"
+      try {
+        const data = await getDiaryStats(Number(y), Number(m));
+        setStats(data);
+      } catch (err) {
+        console.error("📉 통계 데이터 불러오기 실패", err);
+      }
+    };
+    fetchStats();
+  }, [month]);
+
   return (
     <div className={styles.statsContainer}>
       <div className={styles.fixedTop}>
@@ -48,9 +64,9 @@ export default function StatsView() {
       {/* 통계 차트 영역 */}
       <div className={styles.scrollWrapper}>
         <div className={styles.chartSection}>
-          <EmotionStatsCard />
-          <StyleStats />
-          <VisitStats />
+          <EmotionStatsCard data={stats?.topEmotions ?? []} />
+          <StyleStats month={month} />
+          <VisitStats data={stats?.topLocations ?? []} />
         </div>
       </div>
     </div>

--- a/Modi-frontend/src/pages/mypage/StatsView.tsx
+++ b/Modi-frontend/src/pages/mypage/StatsView.tsx
@@ -5,7 +5,10 @@ import styles from "./MyPage.module.css";
 import EmotionStatsCard from "../../components/MyPage/Stats/StatsCard/EmotionStatsCard";
 import StyleStats from "../../components/MyPage/Stats/StatsCard/StyleStats";
 import VisitStats from "../../components/MyPage/Stats/StatsCard/VisitStats";
-import { mockDiaries } from "../../apis/diaryInfo";
+
+import { getEmotionStatsByMonth } from "../../utils/getEmotionStatsByMonth";
+import { getToneStatsByMonth } from "../../utils/getToneStatsByMonths";
+import { getVisitStatsByMonth } from "../../utils/getVisitStatsByMonth";
 
 type Emotion = Diary["emotion"];
 
@@ -19,37 +22,9 @@ export default function StatsView() {
   // 2) 선택된 월 상태
   const [month, setMonth] = useState<string>(allMonths.at(-1)!);
 
-  // 3) 해당 월의 다이어리만 필터
-  const monthDiaries = useMemo(
-    () => allDiaries.filter((d) => d.date.startsWith(month)),
-    [month]
-  );
-
-  // 4) 감정별 카운트 계산
-  const emotionCounts = useMemo(() => {
-    const counts = {} as Record<Emotion, number>;
-    // 초기화
-    monthDiaries.forEach((d) => {
-      if (!(d.emotion in counts)) counts[d.emotion] = 0;
-      counts[d.emotion] += 1;
-    });
-    return counts;
-  }, [monthDiaries]);
-
-  const [stats, setStats] = useState<StatsResponse | null>(null);
-
-  useEffect(() => {
-    const fetchStats = async () => {
-      const [y, m] = month.split("-"); // "2025-07"
-      try {
-        const data = await getDiaryStats(Number(y), Number(m));
-        setStats(data);
-      } catch (err) {
-        console.error("📉 통계 데이터 불러오기 실패", err);
-      }
-    };
-    fetchStats();
-  }, [month]);
+  const emotionStats = useMemo(() => getEmotionStatsByMonth(month), [month]);
+  const toneStats = useMemo(() => getToneStatsByMonth(month), [month]);
+  const visitStats = useMemo(() => getVisitStatsByMonth(month), [month]);
 
   return (
     <div className={styles.statsContainer}>
@@ -64,9 +39,9 @@ export default function StatsView() {
       {/* 통계 차트 영역 */}
       <div className={styles.scrollWrapper}>
         <div className={styles.chartSection}>
-          <EmotionStatsCard data={stats?.topEmotions ?? []} />
-          <StyleStats month={month} />
-          <VisitStats data={stats?.topLocations ?? []} />
+          <EmotionStatsCard data={emotionStats} month={month} />
+          <StyleStats data={toneStats} />
+          <VisitStats data={visitStats} />
         </div>
       </div>
     </div>

--- a/Modi-frontend/src/utils/getEmotionStatsByMonth.ts
+++ b/Modi-frontend/src/utils/getEmotionStatsByMonth.ts
@@ -1,0 +1,18 @@
+import { mockDiaries } from "../apis/diaryInfo";
+
+export function getEmotionStatsByMonth(ym: string) {
+  const filtered = mockDiaries.filter((d) => d.date.startsWith(ym));
+  const counter: Record<string, number> = {};
+
+  filtered.forEach((d) => {
+    if (!d.emotion) return;
+    counter[d.emotion] = (counter[d.emotion] || 0) + 1;
+  });
+
+  const result = Object.entries(counter).map(([name, count]) => ({
+    name,
+    count,
+  }));
+
+  return result.sort((a, b) => b.count - a.count);
+}

--- a/Modi-frontend/src/utils/getEmotionStatsByMonth.ts
+++ b/Modi-frontend/src/utils/getEmotionStatsByMonth.ts
@@ -9,10 +9,10 @@ export function getEmotionStatsByMonth(ym: string) {
     counter[d.emotion] = (counter[d.emotion] || 0) + 1;
   });
 
-  const result = Object.entries(counter).map(([name, count]) => ({
-    name,
-    count,
+  const result = Object.entries(counter).map(([label, value]) => ({
+    label,
+    value,
   }));
 
-  return result.sort((a, b) => b.count - a.count);
+  return result.sort((a, b) => b.value - a.value);
 }

--- a/Modi-frontend/src/utils/getToneStatsByMonths.ts
+++ b/Modi-frontend/src/utils/getToneStatsByMonths.ts
@@ -1,0 +1,18 @@
+import { mockDiaries } from "../apis/diaryInfo";
+
+export function getToneStatsByMonth(ym: string) {
+  const filtered = mockDiaries.filter((d) => d.date.startsWith(ym));
+  const counter: Record<string, number> = {};
+
+  filtered.forEach((d) => {
+    if (!d.tone) return;
+    counter[d.tone] = (counter[d.tone] || 0) + 1;
+  });
+
+  const result = Object.entries(counter).map(([label, value]) => ({
+    label,
+    value,
+  }));
+
+  return result.sort((a, b) => b.value - a.value);
+}

--- a/Modi-frontend/src/utils/getVisitStatsByMonth.ts
+++ b/Modi-frontend/src/utils/getVisitStatsByMonth.ts
@@ -1,0 +1,18 @@
+import { mockDiaries } from "../apis/diaryInfo";
+
+export function getVisitStatsByMonth(ym: string) {
+  const filtered = mockDiaries.filter((d) => d.date.startsWith(ym));
+  const counter: Record<string, number> = {};
+
+  filtered.forEach((d) => {
+    if (!d.address) return;
+    counter[d.address] = (counter[d.address] || 0) + 1;
+  });
+
+  const result = Object.entries(counter).map(([label, value]) => ({
+    label,
+    value,
+  }));
+
+  return result.sort((a, b) => b.value - a.value);
+}

--- a/Modi-frontend/vite.config.ts
+++ b/Modi-frontend/vite.config.ts
@@ -6,6 +6,13 @@ export default defineConfig({
   plugins: [svgr({ exportAsDefault: true }), react()],
   server: {
     open: true,
+    proxy: {
+      "/api": {
+        target: "http://ec2-3-38-55-66.ap-northeast-2.compute.amazonaws.com",
+        changeOrigin: true,
+        rewrite: (path) => path.replace(/^\/api/, ""),
+      },
+    },
   },
   define: {
     global: "globalThis",

--- a/Modi-frontend/vite.config.ts
+++ b/Modi-frontend/vite.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
     open: true,
     proxy: {
       "/api": {
-        target: "http://ec2-3-38-55-66.ap-northeast-2.compute.amazonaws.com",
+        target: "https://modidiary.store/",
         changeOrigin: true,
         rewrite: (path) => path.replace(/^\/api/, ""),
       },


### PR DESCRIPTION
## Related issue 🛠

closed #<issue_number>
어떤 변경사항이 있었나요?

- [x] 기능 추가 (Feature)
- [ ] 기능 제거 (Remove)
- [ ] 버그 수정 (Bugfix)
- [x] 리팩토링 (Refactor)
- [ ] 리뷰 반영 (Review Update)
- [x] 디자인 수정 (Designfix)
- [ ] 문서 작성 및 수정 (Docs: README.md 등)
- [x] 기능 추가 (Feature)
- [ ] 코드 리팩토링 (Refactor)
- [ ] 개발 환경 설정 (Setting)
- [ ] 테스트 관련 (Test: JUnit 등)

## CheckPoint ✅

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] PR 컨벤션에 맞게 작성했습니다. (필수)
- [x] merge할 브랜치의 위치를 확인해 주세요(main❌/개인작업브랜치⭕) (필수)
- [ ] 버그 수정의 경우, 버그의 원인을 파악하였습니다. (선택)

## Work Description ✏️
<img width="366" height="859" alt="image" src="https://github.com/user-attachments/assets/1315ddf7-580f-450d-ab89-dbb9fd3e0fde" />
<img width="358" height="858" alt="image" src="https://github.com/user-attachments/assets/a1a49710-0fb8-4a3c-9631-8856f8d47e81" />

- 즐겨찾기 조회 api 연결 
  - 즐겨찾기 추가/ 해제 api연결에 문제가 생겨 아직 정상적으로 연결 되지 않았는데 오류의 원인을 파악해 보도록 하겠습니다
- 월별 통계 조회 데이터 반영
  - apis 폴더에 있는 diaryItem 내의 임시 데이터를 사용하였습니다
  - 날짜 선택 부분은 api 데이터 정보를 연결하지 않아서 이전 임시 데이터에 있던 날짜(6월, 7월)만 선택할 수 있는 것 같습니다
  - 각 통계 요소들의 최대값이 같을 때는 어떤 값을 최대라고 표현할 지 혹은 어떤 문구를 띄울지 결정이 필요합니다.
 
  ## Uncompleted Tasks 😅

- [ ] 구글 로그인 이메일 프로필 카드에 반영
- [ ] 수정 버튼 클릭 시 닉네임 변경 반영
- [ ] 월별 통계 조회 실제 api 연결

## To Reviewers 📢
통계 컴포넌트의 디자인이나 문구를 띄우는 방식에 대한 아이디어나 개선방향이 있으시면 공유해주시면 좋겠습니다!