### PR TITLE
Feat: 구글 로그인 토큰 요청 방식 추가

### DIFF
--- a/Modi-frontend/src/apis/UserAPIS/editUserInfo.ts
+++ b/Modi-frontend/src/apis/UserAPIS/editUserInfo.ts
@@ -18,7 +18,6 @@ export const editUserInfo = async (
     const response = await axios.put(`${API_BASE_URL}/members/me`, userInfo, {
       headers: {
         "Content-Type": "application/json",
-        // HttpOnly 쿠키는 자동으로 전송되므로 Authorization 헤더 불필요
       },
       withCredentials: true, // HttpOnly 쿠키 자동 전송
     });

--- a/Modi-frontend/src/apis/UserAPIS/signUp.ts
+++ b/Modi-frontend/src/apis/UserAPIS/signUp.ts
@@ -4,7 +4,8 @@ import type { SignUpRequest, SignUpResponse } from "../../types/UserInfo";
 const API_BASE_URL = "https://modidiary.store/api";
 
 export const signUp = async (
-  userInfo: SignUpRequest
+  userInfo: SignUpRequest,
+  code?: string | null
 ): Promise<SignUpResponse> => {
   console.log("=== signUp API 호출 시작 ===");
   console.log("API URL:", `${API_BASE_URL}/users`);
@@ -15,7 +16,12 @@ export const signUp = async (
     console.log("HttpOnly 쿠키 방식으로 인증 진행");
     console.log("현재 모든 쿠키:", document.cookie);
 
-    const response = await axios.post(`${API_BASE_URL}/users`, userInfo, {
+    // code가 있으면 request body에 포함
+    const requestBody = code ? { ...userInfo, code } : userInfo;
+
+    console.log("최종 request body:", requestBody);
+
+    const response = await axios.post(`${API_BASE_URL}/members`, requestBody, {
       headers: {
         "Content-Type": "application/json",
         // HttpOnly 쿠키는 자동으로 전송되므로 Authorization 헤더 불필요
@@ -44,7 +50,11 @@ export const signUp = async (
   }
 };
 
-export const handleUserSignUp = async (nickname: string, character: string) => {
+export const handleUserSignUp = async (
+  nickname: string,
+  character: string,
+  code?: string | null
+) => {
   try {
     console.log("=== handleUserSignUp 시작 ===");
 
@@ -53,7 +63,7 @@ export const handleUserSignUp = async (nickname: string, character: string) => {
       character,
     };
 
-    const response = await signUp(userInfo);
+    const response = await signUp(userInfo, code);
     localStorage.setItem("userInfo", JSON.stringify(response));
     console.log("✅ 회원가입 완료 - localStorage에 사용자 정보 저장");
 

--- a/Modi-frontend/src/apis/UserAPIS/tokenRequest.ts
+++ b/Modi-frontend/src/apis/UserAPIS/tokenRequest.ts
@@ -1,0 +1,90 @@
+import axios from "axios";
+
+const API_BASE_URL = "https://modidiary.store/api";
+
+// 토큰 요청 Request 타입
+interface TokenRequest {
+  code: string;
+}
+
+// 토큰 요청 API
+export const requestToken = async (code: string): Promise<void> => {
+  console.log("=== 토큰 요청 API 호출 시작 ===");
+  console.log("API URL:", `${API_BASE_URL}/oauth2/set-cookie`);
+  console.log("요청 데이터:", { code });
+
+  try {
+    const response = await axios.post(
+      `${API_BASE_URL}/oauth2/set-cookie`,
+      { code } as TokenRequest,
+      {
+        headers: {
+          "Content-Type": "application/json",
+        },
+        withCredentials: true, // HttpOnly 쿠키 자동 전송
+      }
+    );
+
+    console.log("✅ 토큰 요청 성공:", response.status);
+    console.log("응답 헤더:", response.headers);
+
+    // Set-Cookie 헤더 확인
+    const setCookieHeader = response.headers["set-cookie"];
+    if (setCookieHeader) {
+      console.log("Set-Cookie 헤더:", setCookieHeader);
+    }
+
+    return response.data;
+  } catch (error: any) {
+    console.error("❌ 토큰 요청 실패 - 상세 에러 정보:");
+    console.error("에러 타입:", error.constructor.name);
+    console.error("에러 메시지:", error.message);
+
+    if (error.response) {
+      console.error("응답 상태:", error.response.status);
+      console.error("응답 데이터:", error.response.data);
+      console.error("응답 헤더:", error.response.headers);
+    } else if (error.request) {
+      console.error("요청은 보냈지만 응답 없음:", error.request);
+    } else {
+      console.error("요청 설정 에러:", error.message);
+    }
+
+    throw error;
+  }
+};
+
+// 토큰 요청 핸들러 (에러 처리 포함)
+export const handleTokenRequest = async (code: string): Promise<void> => {
+  try {
+    console.log("=== handleTokenRequest 시작 ===");
+    console.log("code:", code);
+
+    await requestToken(code);
+    console.log("✅ 토큰 요청 완료 - HttpOnly 쿠키로 access_token 설정됨");
+  } catch (error: any) {
+    console.error("❌ handleTokenRequest 실패:");
+    console.error("에러 타입:", error.constructor.name);
+    console.error("에러 메시지:", error.message);
+
+    let userMessage = "토큰 요청에 실패했습니다.";
+
+    if (error.response) {
+      const status = error.response.status;
+      const data = error.response.data;
+
+      if (status === 400) {
+        userMessage = "잘못된 요청입니다. code 값을 확인해주세요.";
+      } else if (status === 401) {
+        userMessage = "인증에 실패했습니다. 다시 로그인해주세요.";
+      } else if (status >= 500) {
+        userMessage = "서버 오류가 발생했습니다. 잠시 후 다시 시도해주세요.";
+      }
+    } else if (error.request) {
+      userMessage = "서버에 연결할 수 없습니다. 네트워크 연결을 확인해주세요.";
+    }
+
+    error.userMessage = userMessage;
+    throw error;
+  }
+};

--- a/Modi-frontend/src/pages/home/HomePage.tsx
+++ b/Modi-frontend/src/pages/home/HomePage.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import style from "./HomePage.module.css";
 import Footer from "../../components/common/Footer";
 
@@ -8,11 +8,44 @@ import PhotoView from "./PhotoView";
 import Header from "../../components/common/Header";
 import { allDiaries } from "../../data/diaries"; // 또는 상태 관리 데이터
 import EmptyDiaryView from "./EmptyDiaryView";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useLocation } from "react-router-dom";
+import { handleTokenRequest } from "../../apis/UserAPIS/tokenRequest";
+
+// URL에서 code 파라미터 추출 함수
+const getCodeFromURL = (): string | null => {
+  const urlParams = new URLSearchParams(window.location.search);
+  return urlParams.get("code");
+};
 
 export default function HomePage() {
   const [viewType, setViewType] = useState<"photo" | "polaroid">("polaroid");
   const navigate = useNavigate();
+  const location = useLocation();
+
+  // code 파라미터가 있으면 토큰 요청 처리
+  useEffect(() => {
+    const code = getCodeFromURL();
+    if (code) {
+      console.log("=== 홈 페이지에서 code 파라미터 감지 ===");
+      console.log("code:", code);
+      console.log("기존 회원이므로 토큰 요청 처리");
+
+      // 토큰 요청 API 호출
+      handleTokenRequest(code)
+        .then(() => {
+          console.log("✅ 토큰 요청 완료");
+        })
+        .catch((error) => {
+          console.error("❌ 토큰 요청 실패:", error);
+          navigate("/login");
+        })
+        .finally(() => {
+          // URL에서 code 파라미터 제거
+          const newUrl = window.location.pathname;
+          window.history.replaceState({}, document.title, newUrl);
+        });
+    }
+  }, [location, navigate]);
   return (
     <div className={style.home_wrapper}>
       <div className={style.home_container}>

--- a/Modi-frontend/src/types/UserInfo.ts
+++ b/Modi-frontend/src/types/UserInfo.ts
@@ -2,6 +2,7 @@
 export interface SignUpRequest {
   nickname: string;
   character: string;
+  code?: string; // Google OAuth code (선택적)
 }
 
 // 회원가입, 회원 정보 수정, 회원 정보 조회 응답 인터페이스

--- a/Modi-frontend/src/types/set-cookie.ts
+++ b/Modi-frontend/src/types/set-cookie.ts
@@ -1,0 +1,5 @@
+// 로그인 후 토큰 요청할 때 쓰일 request body
+// body에 앞서 전달받은 code를 포함하여 보내면 응답 헤더에 Set-Cookie로 access_token이 포함됨
+export interface CookieRequest {
+  code: string;
+}


### PR DESCRIPTION
## Related issue 🛠

closed #<issue_number>
어떤 변경사항이 있었나요?

- [x] 기능 추가 (Feature)
- [ ] 기능 제거 (Remove)
- [ ] 버그 수정 (Bugfix)
- [ ] 리팩토링 (Refactor)
- [ ] 리뷰 반영 (Review Update)
- [ ] 디자인 수정 (Designfix)
- [ ] 문서 작성 및 수정 (Docs: README.md 등)
- [x] 기능 추가 (Feature)
- [ ] 코드 리팩토링 (Refactor)
- [ ] 개발 환경 설정 (Setting)
- [x] 테스트 관련 (Test: JUnit 등)

## CheckPoint ✅

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] PR 컨벤션에 맞게 작성했습니다. (필수)
- [x] merge할 브랜치의 위치를 확인해 주세요(main❌/개인작업브랜치⭕) (필수)
- [ ] 버그 수정의 경우, 버그의 원인을 파악하였습니다. (선택)

## Work Description ✏️

- 구글 로그인 시에 리디렉션 url과 token을 같이 받는 방식이 아니라 리디렉션 url 먼저 받고, 페이지 이동 후 token을 다시 서버에 요청하는 방식으로 API를 추가하였습니다 !
- 아래 사진처럼 로그인했을 때 애플리케이션 > 쿠키 에서 정상적으로 'access_token'을 확인할 수 있습니다!

<img width="3420" height="1854" alt="image" src="https://github.com/user-attachments/assets/d628ec4a-8db6-4570-867b-a7d9e6d1233f" />
<img width="3420" height="1854" alt="image" src="https://github.com/user-attachments/assets/a1c37760-c60c-4c7f-8db2-cdb8a389e9a5" />


## Uncompleted Tasks 😅

- [ ] Task1

## To Reviewers 📢
