### PR TITLE
Feat(mypage): 통계 조회 API 연동 및 유틸 수정

### DIFF
--- a/Modi-frontend/src/apis/MyPageAPIS/favorites.ts
+++ b/Modi-frontend/src/apis/MyPageAPIS/favorites.ts
@@ -1,4 +1,4 @@
-import apiClient from "./apiClient";
+import apiClient from "../apiClient";
 
 type FavoriteItemRaw = {
   id: number;

--- a/Modi-frontend/src/apis/MyPageAPIS/stats.ts
+++ b/Modi-frontend/src/apis/MyPageAPIS/stats.ts
@@ -1,4 +1,4 @@
-import apiClient from "./apiClient";
+import apiClient from "../apiClient";
 
 export interface StatisticsItem {
   name: string;

--- a/Modi-frontend/src/pages/diary/RecordDetailPage.tsx
+++ b/Modi-frontend/src/pages/diary/RecordDetailPage.tsx
@@ -10,7 +10,7 @@ import DeleteButton from "../../components/common/button/ButtonIcon/DeleteButton
 import { useFrameTemplate } from "../../contexts/FrameTemplate";
 import { useNavigate, useLocation } from "react-router-dom";
 import { DiaryData } from "../../components/common/frame/Frame";
-import { updateFavorite } from "../../apis/favorites";
+import { updateFavorite } from "../../apis/MyPageAPIS/favorites";
 import { overflow } from "html2canvas/dist/types/css/property-descriptors/overflow";
 
 const pageBackgrounds = {

--- a/Modi-frontend/src/pages/mypage/FavoriteView.tsx
+++ b/Modi-frontend/src/pages/mypage/FavoriteView.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from "react";
-import { FavoriteItem, getFavorites } from "../../apis/favorites";
+import { FavoriteItem, getFavorites } from "../../apis/MyPageAPIS/favorites";
 import FavoriteDiary from "../../components/MyPage/Favorite/FavoriteDiary";
 import styles from "./MyPage.module.css";
 

--- a/Modi-frontend/src/utils/getEmotionStatsByMonth.ts
+++ b/Modi-frontend/src/utils/getEmotionStatsByMonth.ts
@@ -1,18 +1,8 @@
-import { mockDiaries } from "../apis/diaryInfo";
+import { fetchStatisticsByYm } from "./statisticsFetcher";
 
-export function getEmotionStatsByMonth(ym: string) {
-  const filtered = mockDiaries.filter((d) => d.date.startsWith(ym));
-  const counter: Record<string, number> = {};
-
-  filtered.forEach((d) => {
-    if (!d.emotion) return;
-    counter[d.emotion] = (counter[d.emotion] || 0) + 1;
-  });
-
-  const result = Object.entries(counter).map(([label, value]) => ({
-    label,
-    value,
-  }));
-
-  return result.sort((a, b) => b.value - a.value);
+export async function getEmotionStatsByMonth(ym: string) {
+  const data = await fetchStatisticsByYm(ym);
+  return (data.topEmotions ?? [])
+    .map((it) => ({ label: it.name, value: it.count }))
+    .sort((a, b) => b.value - a.value);
 }

--- a/Modi-frontend/src/utils/getToneStatsByMonths.ts
+++ b/Modi-frontend/src/utils/getToneStatsByMonths.ts
@@ -1,18 +1,8 @@
-import { mockDiaries } from "../apis/diaryInfo";
+import { fetchStatisticsByYm } from "./statisticsFetcher";
 
-export function getToneStatsByMonth(ym: string) {
-  const filtered = mockDiaries.filter((d) => d.date.startsWith(ym));
-  const counter: Record<string, number> = {};
-
-  filtered.forEach((d) => {
-    if (!d.tone) return;
-    counter[d.tone] = (counter[d.tone] || 0) + 1;
-  });
-
-  const result = Object.entries(counter).map(([label, value]) => ({
-    label,
-    value,
-  }));
-
-  return result.sort((a, b) => b.value - a.value);
+export async function getToneStatsByMonth(ym: string) {
+  const data = await fetchStatisticsByYm(ym);
+  return (data.topTones ?? [])
+    .map((it) => ({ label: it.name, value: it.count }))
+    .sort((a, b) => b.value - a.value);
 }

--- a/Modi-frontend/src/utils/getVisitStatsByMonth.ts
+++ b/Modi-frontend/src/utils/getVisitStatsByMonth.ts
@@ -1,16 +1,17 @@
-import { mockDiaries } from "../apis/diaryInfo";
+import { fetchStatisticsByYm } from "./statisticsFetcher";
 import { extractSiDong } from "./address";
 
-export function getVisitStatsByMonth(ym: string) {
-  const filtered = mockDiaries.filter((d) => d.date.startsWith(ym));
+export async function getVisitStatsByMonth(ym: string) {
+  const stats = await fetchStatisticsByYm(ym); // 캐시로 1회 호출
   const counter: Record<string, number> = {};
 
-  filtered.forEach((d) => {
-    if (!d.address) return;
-    const label = extractSiDong(d.address);
-    if (!label) return;
-    counter[label] = (counter[label] || 0) + 1;
-  });
+  for (const loc of stats.topLocations ?? []) {
+    // 응답 name(예: "서울시 강남구\n역삼동" 또는 "역삼동")을 표준화
+    const normalized = extractSiDong(loc.name);
+    const label = normalized || loc.name || ""; // 파서가 빈 문자열 내면 원본 사용
+    if (!label) continue;
+    counter[label] = (counter[label] || 0) + (loc.count ?? 0);
+  }
 
   return Object.entries(counter)
     .map(([label, value]) => ({ label, value }))

--- a/Modi-frontend/src/utils/statisticsFetcher.ts
+++ b/Modi-frontend/src/utils/statisticsFetcher.ts
@@ -1,0 +1,16 @@
+import { getStatistics, StatisticsResponse } from "../apis/MyPageAPIS/stats";
+
+const cache = new Map<string, StatisticsResponse>(); // key: "YYYY-MM"
+
+function parseYm(ym: string) {
+  const [y, mm] = ym.split("-");
+  return { year: y, month: String(Number(mm)) }; // "08" → "8"
+}
+
+export async function fetchStatisticsByYm(ym: string) {
+  if (cache.has(ym)) return cache.get(ym)!;
+  const { year, month } = parseYm(ym);
+  const { data } = await getStatistics(year, month);
+  cache.set(ym, data);
+  return data;
+}


### PR DESCRIPTION
## Related issue 🛠

closed #<issue_number>
어떤 변경사항이 있었나요?

- [x] 기능 추가 (Feature)
- [ ] 기능 제거 (Remove)
- [ ] 버그 수정 (Bugfix)
- [ ] 리팩토링 (Refactor)
- [ ] 리뷰 반영 (Review Update)
- [ ] 디자인 수정 (Designfix)
- [ ] 문서 작성 및 수정 (Docs: README.md 등)
- [x] 기능 추가 (Feature)
- [ ] 코드 리팩토링 (Refactor)
- [ ] 개발 환경 설정 (Setting)
- [ ] 테스트 관련 (Test: JUnit 등)

## CheckPoint ✅

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] PR 컨벤션에 맞게 작성했습니다. (필수)
- [x] merge할 브랜치의 위치를 확인해 주세요(main❌/개인작업브랜치⭕) (필수)
- [ ] 버그 수정의 경우, 버그의 원인을 파악하였습니다. (선택)

## Work Description ✏️

- 마이페이지 통계 API(/api/diaries/statistics) 연동
  - 기존 mockDiaries 기반 통계 계산 로직을 실제 API 데이터 기반으로 변경
  - 감정(getEmotionStatsByMonth), 톤(getToneStatsByMonth), 방문지역(getVisitStatsByMonth) 유틸에 API 연결

- fetchStatisticsByYm 공용 fetcher 추가
  - 월별 통계 API 호출을 공용 함수로 분리하고 메모리 캐시 적용 → 같은 월 데이터 중복 호출 방지

- StatsView 로직 수정
  - 유틸이 비동기(async)로 변경됨에 따라 useEffect + useState로 데이터 로딩 구조 변경
  - 로딩/에러 상태 표시 추가

## Uncompleted Tasks 😅

- [ ] Task1

## To Reviewers 📢
