### PR TITLE
Feat(home):일기상세보기 api 연동

### DIFF
--- a/Modi-frontend/src/apis/Diary/diaries.read.ts
+++ b/Modi-frontend/src/apis/Diary/diaries.read.ts
@@ -74,3 +74,34 @@ export const fetchDailyGroups = async (
     .map(([date, ds]) => ({ date, diaries: ds }))
     .sort((a, b) => a.date.localeCompare(b.date));
 };
+
+export const fetchDiaryById = async (
+  diaryId: number | string
+): Promise<DiaryData> => {
+  const res = await apiClient.get(`/diaries/${diaryId}`);
+  // 명세서에 따라 DiaryData로 변환
+  return normalizeDiaryDetail(res.data);
+};
+
+// 상세 일기 데이터 변환 함수
+function normalizeDiaryDetail(r: any): DiaryData {
+  return {
+    id: Number(r.id),
+    date: (r.date ?? "").slice(0, 10),
+    photoUrl: r.imageUrls?.[0] ?? "",
+    summary: r.summary ?? "",
+    emotion: typeof r.emotion === "object" ? r.emotion.name : r.emotion ?? "",
+    tags: Array.isArray(r.tags)
+      ? r.tags.map((t: any) =>
+          t && typeof t === "object" ? t.name ?? "" : String(t)
+        )
+      : [],
+    content: r.content,
+    address: r.location?.address ?? "",
+    latitude: r.location?.latitude,
+    longitude: r.location?.longitude,
+    tone: typeof r.tone === "object" ? r.tone.name : r.tone ?? "",
+    font: r.font,
+    frame: r.frameId,
+  };
+}

--- a/Modi-frontend/src/apis/Diary/diaries.read.ts
+++ b/Modi-frontend/src/apis/Diary/diaries.read.ts
@@ -15,7 +15,7 @@ const normalize = (r: any): DiaryData => ({
   longitude: r.longitude,
   tone: r.tone,
   font: r.font,
-  frame: r.frame,
+  frame: r.frameId ?? r.frame,
 });
 
 export const fetchMonthlyDiaries = async (
@@ -102,6 +102,6 @@ function normalizeDiaryDetail(r: any): DiaryData {
     longitude: r.location?.longitude,
     tone: typeof r.tone === "object" ? r.tone.name : r.tone ?? "",
     font: r.font,
-    frame: r.frameId,
+    frame: r.frameId ?? r.frame,
   };
 }

--- a/Modi-frontend/src/components/HomePage/Diary/Polaroid/PolaroidFrame.tsx
+++ b/Modi-frontend/src/components/HomePage/Diary/Polaroid/PolaroidFrame.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from "react";
 import Frame from "../../../common/frame/Frame";
 import styles from "./PolaroidDiary.module.css";
 import { useNavigate } from "react-router-dom";
-import { mockFetchDiaryById } from "../../../../apis/diaryInfo";
+import { fetchDiaryById } from "../../../../apis/Diary/diaries.read";
 import { DiaryData } from "../../../common/frame/Frame";
 
 interface Props {
@@ -35,7 +35,7 @@ const PolaroidFrame: React.FC<Props> = ({
         setLoading(true);
         setError(null);
         try {
-          const data = await mockFetchDiaryById(diaryId.toString());
+          const data = await fetchDiaryById(diaryId);
           setDiary(data);
         } catch (err) {
           setError(
@@ -48,7 +48,6 @@ const PolaroidFrame: React.FC<Props> = ({
           setLoading(false);
         }
       };
-
       fetchDiary();
     }
   }, [diaryId, diaryData]);

--- a/Modi-frontend/src/pages/home/PolaroidView.tsx
+++ b/Modi-frontend/src/pages/home/PolaroidView.tsx
@@ -243,10 +243,17 @@ export default function PolaroidView({ onSwitchView }: PolaroidViewProps) {
                 // 이전/다음 날짜: 대표 일기(첫 번째)
                 diary = diariesByDate[allDates[i]]?.[0] ?? null;
               }
+              if (diary) {
+                console.log("diary id:", diary.id, "frame:", diary.frame);
+              }
               return (
                 <div key={i} className={cls}>
                   {diary ? (
-                    <PolaroidFrame diaryData={diary} diaryId={diary.id} />
+                    <PolaroidFrame
+                      key={diary.id}
+                      diaryData={diary}
+                      diaryId={diary.id}
+                    />
                   ) : (
                     <div className={pageStyles.emptySlot} />
                   )}


### PR DESCRIPTION
## Related issue 🛠

closed #<issue_number>
어떤 변경사항이 있었나요?

- [x] 기능 추가 (Feature)
- [ ] 기능 제거 (Remove)
- [ ] 버그 수정 (Bugfix)
- [ ] 리팩토링 (Refactor)
- [ ] 리뷰 반영 (Review Update)
- [ ] 디자인 수정 (Designfix)
- [ ] 문서 작성 및 수정 (Docs: README.md 등)
- [x] 기능 추가 (Feature)
- [ ] 코드 리팩토링 (Refactor)
- [ ] 개발 환경 설정 (Setting)
- [ ] 테스트 관련 (Test: JUnit 등)

## CheckPoint ✅

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] PR 컨벤션에 맞게 작성했습니다. (필수)
- [x] merge할 브랜치의 위치를 확인해 주세요(main❌/개인작업브랜치⭕) (필수)
- [ ] 버그 수정의 경우, 버그의 원인을 파악하였습니다. (선택)

## Work Description ✏️

- 일기 상세보기 api를 연동하여 각각 PolaroidFrame에 적용되도록 했습니다.
- PolaroidView 클릭 시 기록 상세보기로 이동했을 때 생성했을 당시 선택한 FrameId에 맞는 디자인이 적절하게 적용되어 있으나 다시 전 페이지인 메인화면으로 돌아오면 모든 일기의 디자인이 통일되어 보이는 문제(메인화면에서 FrameID가 undefine상태)가 있어서 이를 메인화면에서 Frame 적용방식을 수정하여 고쳐보도록하겠습니다...!

## Uncompleted Tasks 😅

- [ ] Task1

## To Reviewers 📢
