### PR TITLE
Fix, Refactor : 콘솔 삭제, 코드 구조 리팩토링, 주소 문자열 표준화

### DIFF
--- a/Modi-frontend/src/apis/Diary/diaries.read.ts
+++ b/Modi-frontend/src/apis/Diary/diaries.read.ts
@@ -41,8 +41,6 @@ export const fetchMonthlyDiaries = async (
   const { data } = await apiClient.get("/diaries", { params: { year, month } });
   const list = Array.isArray(data) ? data : data?.diaries ?? data?.items ?? [];
   const mapped = list.map(normalize);
-  console.log("[monthly] raw sample:", list[0]);
-  console.log("[monthly] normalized sample:", mapped[0]); // 🔎 frame 확인
   return mapped;
 };
 
@@ -71,7 +69,6 @@ export const fetchDailyGroups = async (
         diaries: (g.diaries as any[]).map(normalize).filter((d) => d.date),
       }))
       .sort((a, b) => a.date.localeCompare(b.date));
-    console.log("[daily groups] normalized sample:", groups[0]?.diaries?.[0]);
     return groups;
   }
 

--- a/Modi-frontend/src/apis/MyPageAPIS/favorites.ts
+++ b/Modi-frontend/src/apis/MyPageAPIS/favorites.ts
@@ -4,9 +4,9 @@ type FavoriteItemRaw = {
   id: number;
   date: string;
   thumbnailUrl?: string;
-  photoUrl?: string; // 'https://...'
-  imageUrl?: string; // 다른 이름일 수도
-  thumbnailId?: string; // '99464d7-...' 같은 키
+  photoUrl?: string;
+  imageUrl?: string;
+  thumbnailId?: string;
 };
 
 export type FavoriteItem = {

--- a/Modi-frontend/src/apis/apiClient.ts
+++ b/Modi-frontend/src/apis/apiClient.ts
@@ -1,4 +1,4 @@
-import axios from "axios";
+import axios, { AxiosError } from "axios";
 
 const apiClient = axios.create({
   baseURL: "https://modidiary.store/api",
@@ -9,36 +9,54 @@ const apiClient = axios.create({
 
 // 토큰 + FormData 헤더 처리
 apiClient.interceptors.request.use((config) => {
-  const token = localStorage.getItem("accessToken"); // ✅ devToken fallback 제거 권장
-  if (token) {
-    config.headers = config.headers ?? {};
-    config.headers.Authorization = `Bearer ${token}`;
+  if (config.data instanceof FormData && config.headers) {
+    delete (config.headers as any)["Content-Type"];
+    delete (config.headers as any)["content-type"];
   }
-
-  // ✅ FormData면 Content-Type 없애서 axios가 boundary 자동생성하도록
-  if (config.data instanceof FormData) {
-    if (config.headers) {
-      delete (config.headers as any)["Content-Type"];
-      delete (config.headers as any)["content-type"];
-    }
-  } else {
-    // JSON 보낼 때만 명시 (선택)
-    config.headers = config.headers ?? {};
-    (config.headers as any)["Content-Type"] = "application/json";
-  }
-
-  // 디버그
-  console.log(
-    "[api req]",
-    config.method,
-    config.baseURL,
-    config.url,
-    "Auth?",
-    !!token,
-    "FD?",
-    config.data instanceof FormData
-  );
   return config;
 });
+
+let isRefreshing = false;
+
+apiClient.interceptors.response.use(
+  (res) => res,
+  async (error: AxiosError) => {
+    const original = error.config as any;
+    const status = error.response?.status;
+
+    // 이미 한 번 재시도했다면 그대로 에러 반환
+    if (original?._retry) throw error;
+
+    // 예시: CSRF 토큰 만료(419) 또는 금지(403)일 때 재발급 후 재시도
+    if (status === 419 || (status === 403 && !isRefreshing)) {
+      try {
+        isRefreshing = true;
+        // ⬇️ 서버에 맞는 CSRF 재발급 엔드포인트로 변경하세요
+        await apiClient.get("/auth/csrf"); // e.g. /auth/csrf or /sanctum/csrf-cookie
+        isRefreshing = false;
+        original._retry = true;
+        return apiClient(original);
+      } catch (e) {
+        isRefreshing = false;
+        throw error;
+      }
+    }
+
+    // 예시: 세션 만료(401) → 리프레시 시도 후 재요청
+    if (status === 401 && !original?._retry) {
+      try {
+        // ⬇️ 서버에 맞는 리프레시 엔드포인트로 변경하세요
+        await apiClient.post("/auth/refresh");
+        original._retry = true;
+        return apiClient(original);
+      } catch {
+        // 새로고침 실패 시 로그인 페이지로 보내거나 상태 초기화
+        // window.location.href = "/login";
+      }
+    }
+
+    throw error;
+  }
+);
 
 export default apiClient;

--- a/Modi-frontend/src/components/MyPage/Stats/ChartItem/StyleStatsBar.tsx
+++ b/Modi-frontend/src/components/MyPage/Stats/ChartItem/StyleStatsBar.tsx
@@ -27,7 +27,7 @@ export default function StyleBar({
   isMax,
   maxColor,
   character,
-  multilineAfterSi = false,
+  multilineAfterSi = true,
 }: Props) {
   const hasValue = typeof value === "number";
   const isZuni = character === "zuni";
@@ -35,8 +35,8 @@ export default function StyleBar({
   const offset = ZUNI_MAX_HEIGHT - height;
 
   const displayLabel = (label ?? "").replace(
-    multilineAfterSi ? /시\s+/ : /$^/, // 조건일 때만 매칭
-    "시\n"
+    multilineAfterSi ? /(시|구)(?!\n)/g : /$^/,
+    "$1\n"
   );
   return (
     <div className={style.barItem}>

--- a/Modi-frontend/src/components/MyPage/Stats/ChartItem/VisitStatsBarList.tsx
+++ b/Modi-frontend/src/components/MyPage/Stats/ChartItem/VisitStatsBarList.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useMemo } from "react";
 import StyleBar from "./StyleStatsBar";
 import style from "./StyleStatsBar.module.css";
 import { useCharacter } from "../../../../contexts/CharacterContext";
@@ -15,20 +15,54 @@ interface StyleDataItem {
 interface VisitStatsBarListProps {
   data: StyleDataItem[];
   onMaxLabelChange?: (label: string) => void;
+  multilineAfterSi?: boolean;
 }
 
 export default function VisitStatsBarList({
   data,
   onMaxLabelChange,
+  multilineAfterSi,
 }: VisitStatsBarListProps) {
   const { character } = useCharacter();
-  if (!character || data.length === 0) return null;
+  // 아이콘 경로
+  const iconPaths = useMemo(() => {
+    if (!character) return { base: "", color: "" };
+    const base = `/images/character-statsbar/${character}/${character}_head.svg`;
+    const color = `/images/character-statsbar/${character}/${character}_head_color.svg`;
+    return { base, color };
+  }, [character]);
 
-  const iconPath = `/images/character-statsbar/${character}/${character}_head.svg`;
-  const coloredIcon = `/images/character-statsbar/${character}/${character}_head_color.svg`;
+  // 최대값/최대라벨
+  const max = useMemo(
+    () => (data.length ? Math.max(...data.map((d) => d.value)) : 0),
+    [data]
+  );
 
-  const max = Math.max(...data.map((d) => d.value));
-  const maxLabel = data.find((d) => d.value === max)?.label;
+  const maxLabel = useMemo(() => {
+    if (!data.length || max <= 0) return undefined;
+    return data.find((d) => d.value === max)?.label;
+  }, [data, max]);
+
+  const realTop = useMemo(() => {
+    if (!character || !data.length)
+      return [] as Array<{
+        label: string;
+        value?: number;
+        height: number;
+        isMax: boolean;
+        icon: string;
+      }>;
+
+    return [...data]
+      .sort((a, b) => b.value - a.value)
+      .slice(0, MAX_ITEMS)
+      .map((d) => ({
+        ...d,
+        height: max > 0 ? (d.value / max) * MAX_BAR_HEIGHT : 0,
+        isMax: d.value === max,
+        icon: d.value === max ? iconPaths.color : iconPaths.base,
+      }));
+  }, [character, data, max, iconPaths]);
 
   // maxLabel이 변경되면 부모에 알림
   useEffect(() => {
@@ -37,6 +71,8 @@ export default function VisitStatsBarList({
     }
   }, [onMaxLabelChange, maxLabel]);
 
+  if (!character) return null;
+
   const maxBarColorMap: Record<string, string> = {
     momo: "#FBD7D5",
     boro: "#FEE888",
@@ -44,66 +80,20 @@ export default function VisitStatsBarList({
     zuni: "#93D1E0",
   };
 
-  const normalized = [...data]
-    .sort((a, b) => b.value - a.value) // 내림차순 정렬
-    .map((d) => ({
-      ...d,
-      height: (d.value / max) * MAX_BAR_HEIGHT,
-      isMax: d.value === max,
-      icon: iconPath,
-    }));
-
-  if (data.length === 0) {
-    // 전부 placeholder (아이콘만)
-    return (
-      <div className={style.barList}>
-        {Array.from({ length: MAX_ITEMS }).map((_, i) => (
-          <StyleBar
-            key={`placeholder-${i}`}
-            label=""
-            value={undefined}
-            height={0}
-            icon={iconPath}
-            isMax={false}
-            character={character}
-          />
-        ))}
-      </div>
-    );
-  }
-
-  // 실제 데이터 정렬 → 상한 N개로 자르기
-  const realTop = [...data]
-    .sort((a, b) => b.value - a.value)
-    .slice(0, MAX_ITEMS)
-    .map((d) => ({
-      ...d,
-      height: (d.value / (max || 1)) * MAX_BAR_HEIGHT,
-      isMax: d.value === max,
-      icon: d.value === max ? coloredIcon : iconPath,
-    }));
-
-  // 부모에 최대 라벨 전달(실제 데이터가 있을 때만)
-  useEffect(() => {
-    if (onMaxLabelChange && realTop.length > 0) {
-      onMaxLabelChange(realTop[0].label);
-    }
-  }, [onMaxLabelChange, realTop]);
-
-  // 부족하면 placeholder로 채우기(아이콘만)
-  while (realTop.length < MAX_ITEMS) {
-    realTop.push({
+  const filled = [...realTop];
+  while (filled.length < MAX_ITEMS) {
+    filled.push({
       label: "",
-      value: undefined as any,
+      value: undefined,
       height: 0,
       isMax: false,
-      icon: iconPath,
+      icon: iconPaths.base,
     });
   }
 
   return (
     <div className={style.barList}>
-      {realTop.map((item, idx) => (
+      {filled.map((item, idx) => (
         <StyleBar
           key={item.label || `placeholder-${idx}`}
           label={item.label}
@@ -113,7 +103,7 @@ export default function VisitStatsBarList({
           isMax={item.isMax}
           maxColor={maxBarColorMap[character]}
           character={character}
-          multilineAfterSi
+          multilineAfterSi={multilineAfterSi}
         />
       ))}
     </div>

--- a/Modi-frontend/src/components/MyPage/TabBar.tsx
+++ b/Modi-frontend/src/components/MyPage/TabBar.tsx
@@ -1,4 +1,3 @@
-import React, { useState } from "react";
 import Tab from "../../components/common/tab/Tab";
 import styles from "./TabBar.module.css"; // 아래 CSS 모듈
 

--- a/Modi-frontend/src/components/common/tab/Tab.tsx
+++ b/Modi-frontend/src/components/common/tab/Tab.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import styles from "./Tab.module.css";
 
 interface TabProps {
@@ -8,13 +7,6 @@ interface TabProps {
 }
 
 export default function Tab({ label, selected, onClick }: TabProps) {
-  console.log(
-    label,
-    "selected:",
-    selected,
-    "→ class:",
-    selected ? styles.selected : styles.unselected
-  );
   return (
     <div className={styles.container}>
       <span

--- a/Modi-frontend/src/contexts/CharacterContext.tsx
+++ b/Modi-frontend/src/contexts/CharacterContext.tsx
@@ -24,64 +24,40 @@ export const CharacterProvider: React.FC<React.PropsWithChildren> = ({
 }) => {
   const [character, setCharacter] = useState<CharacterType>(() => {
     const init = (localStorage.getItem("character") as CharacterType) || null;
-    console.log("[CharacterProvider:init] localStorage.character =", init);
     return init;
   });
   const [nickname, setNickname] = useState<string | null>(() => {
     const init = localStorage.getItem("nickname");
-    console.log("[CharacterProvider:init] localStorage.nickname =", init);
     return init;
   });
 
   // setter + 로컬스토리지 동기화 + 로그
   const saveCharacter = (c: CharacterType) => {
-    console.log("[CharacterProvider:setCharacter] new =", c);
     setCharacter(c);
     if (c) {
       localStorage.setItem("character", c);
     } else {
       localStorage.removeItem("character");
     }
-    console.log(
-      "[CharacterProvider:setCharacter] localStorage.character =",
-      localStorage.getItem("character")
-    );
   };
   const saveNickname = (n: string | null) => {
-    console.log("[CharacterProvider:setNickname] new =", n);
     setNickname(n);
     if (n) {
       localStorage.setItem("nickname", n);
     } else {
       localStorage.removeItem("nickname");
     }
-    console.log(
-      "[CharacterProvider:setNickname] localStorage.nickname =",
-      localStorage.getItem("nickname")
-    );
   };
 
   const refreshFromServer = async () => {
-    console.log("[CharacterProvider:refreshFromServer] start");
     try {
       const me = await loadUserInfo();
-      console.log("[CharacterProvider:refreshFromServer] success:", me);
       saveCharacter(me.character);
       saveNickname(me.nickname);
     } catch (e) {
-      console.warn("[CharacterProvider:refreshFromServer] failed:", e);
       // 로그인되지 않은 상태이므로 로컬 스토리지 값 유지
     }
   };
-
-  useEffect(() => {
-    console.log(
-      "[CharacterProvider:state] character =",
-      character,
-      "/ nickname =",
-      nickname
-    );
-  }, [character, nickname]);
 
   return (
     <CharacterContext.Provider

--- a/Modi-frontend/src/pages/home/PolaroidView.tsx
+++ b/Modi-frontend/src/pages/home/PolaroidView.tsx
@@ -243,9 +243,7 @@ export default function PolaroidView({ onSwitchView }: PolaroidViewProps) {
                 // 이전/다음 날짜: 대표 일기(첫 번째)
                 diary = diariesByDate[allDates[i]]?.[0] ?? null;
               }
-              if (diary) {
-                console.log("diary id:", diary.id, "frame:", diary.frame);
-              }
+
               return (
                 <div key={i} className={cls}>
                   {diary ? (

--- a/Modi-frontend/src/pages/mypage/FavoriteView.tsx
+++ b/Modi-frontend/src/pages/mypage/FavoriteView.tsx
@@ -11,7 +11,6 @@ export default function FavoriteView() {
       try {
         const list = await getFavorites();
         // 디버그: 들어오는 최종 URL 확인
-        console.table(list.map((x) => ({ id: x.id, url: x.imageSrc })));
         setFavorites(list);
       } catch (err) {
         console.error("❌ 즐겨찾기 불러오기 실패:", err);

--- a/Modi-frontend/src/utils/MapMarkerImages.ts
+++ b/Modi-frontend/src/utils/MapMarkerImages.ts
@@ -24,8 +24,6 @@ const modules = import.meta.glob(
   }
 );
 
-console.log("🔍 glob 결과:", Object.keys(modules));
-
 export const mapMarkerIconMap: Record<
   CharacterKey,
   Partial<Record<Emotion, string>>

--- a/Modi-frontend/src/utils/emotionImages.ts
+++ b/Modi-frontend/src/utils/emotionImages.ts
@@ -21,10 +21,6 @@ const modules = import.meta.glob(["../assets/emotion_home/**/*.svg"], {
   eager: true,
 });
 
-console.log("💡 emotion modules keys:", Object.keys(modules));
-
-console.log("🌱 modules:", modules);
-
 export const emotionIconMap: Partial<
   Record<CharacterKey, Partial<Record<Emotion, string>>>
 > = {};
@@ -36,10 +32,9 @@ Object.entries(modules).forEach(([path, url]) => {
   const match = fileName.match(/home_[^-]+-([^.]+)\.svg/)!;
   if (!match) return;
 
-  const slug = match[1]; // "sad"
-  console.log("🪲 found slug:", slug, "for file:", fileName);
-  const emotion = slugToEmotion[slug]; // "슬픔"
-  console.log("🪲 mapped emotion:", emotion);
+  const slug = match[1];
+  const emotion = slugToEmotion[slug];
+
   if (!emotion) return;
 
   if (!emotionIconMap[characterKey]) {

--- a/Modi-frontend/src/utils/getToneStatsByMonths.ts
+++ b/Modi-frontend/src/utils/getToneStatsByMonths.ts
@@ -2,7 +2,6 @@ import { fetchStatisticsByYm } from "./statisticsFetcher";
 
 export async function getToneStatsByMonth(ym: string) {
   const data = await fetchStatisticsByYm(ym);
-  console.log("toneData", data);
   return (data.topTones ?? [])
     .map((it) => ({ label: it.name, value: it.count }))
     .sort((a, b) => b.value - a.value);

--- a/Modi-frontend/src/utils/getVisitStatsByMonth.ts
+++ b/Modi-frontend/src/utils/getVisitStatsByMonth.ts
@@ -1,5 +1,5 @@
 import { fetchStatisticsByYm } from "./statisticsFetcher";
-import { extractSiDong } from "./address";
+import { formatVisitLabel } from "./address";
 
 export async function getVisitStatsByMonth(ym: string) {
   const stats = await fetchStatisticsByYm(ym); // 캐시로 1회 호출
@@ -7,7 +7,7 @@ export async function getVisitStatsByMonth(ym: string) {
 
   for (const loc of stats.topLocations ?? []) {
     // 응답 name(예: "서울시 강남구\n역삼동" 또는 "역삼동")을 표준화
-    const normalized = extractSiDong(loc.name);
+    const normalized = formatVisitLabel(loc.name);
     const label = normalized || loc.name || ""; // 파서가 빈 문자열 내면 원본 사용
     if (!label) continue;
     counter[label] = (counter[label] || 0) + (loc.count ?? 0);


### PR DESCRIPTION
## Related issue 🛠

closed #<issue_number>
어떤 변경사항이 있었나요?

- [ ] 기능 추가 (Feature)
- [ ] 기능 제거 (Remove)
- [x] 버그 수정 (Bugfix)
- [x] 리팩토링 (Refactor)
- [ ] 리뷰 반영 (Review Update)
- [ ] 디자인 수정 (Designfix)
- [ ] 문서 작성 및 수정 (Docs: README.md 등)
- [ ] 기능 추가 (Feature)
- [ ] 코드 리팩토링 (Refactor)
- [ ] 개발 환경 설정 (Setting)
- [ ] 테스트 관련 (Test: JUnit 등)

## CheckPoint ✅

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] PR 컨벤션에 맞게 작성했습니다. (필수)
- [x] merge할 브랜치의 위치를 확인해 주세요(main❌/개인작업브랜치⭕) (필수)
- [ ] 버그 수정의 경우, 버그의 원인을 파악하였습니다. (선택)

## Work Description ✏️
<img width="341" height="251" alt="image" src="https://github.com/user-attachments/assets/ee492da8-19d9-491e-89ff-261a9a6e4941" />

- apiClient 에서 쿠키로 토큰 불러오는 코드만 반영, 콘솔 로그 삭제
- 마이페이지 통계 컴포넌트 hook 순서 오류 수정 및 구조 리팩토링
- 마이페이지 통계 컴포넌트에서 기존의 주소를 불러와서 유틸을 이용해서 시, 동만 보여주는 구조로 적용했었는데(서울특별시 광진구 화양동 -> 서울시 화양동) 실제 일기 생성시 그냥 서울 광진구 화양동1 과 같은 형식으로 불러와서 유틸 적용이 잘 되지 않는 문제가 발생했습니다. 이 경우도 반영하여 모두 시, 동만 붙여서 보여주도록 util을 개선했습니다.


## Uncompleted Tasks 😅

- [ ] Task1

## To Reviewers 📢
