### PR TITLE
Fix(home): 일기 월별 조회 전체 월 불러오는 문제 수정

### DIFF
--- a/Modi-frontend/src/components/HomePage/DateSelect/DateSelector.tsx
+++ b/Modi-frontend/src/components/HomePage/DateSelect/DateSelector.tsx
@@ -32,7 +32,6 @@ const DateSelector: React.FC<Props> = ({
   const ITEM_HEIGHT = 40;
   const VISIBLE = viewType === "polaroid" ? 3 : 2;
   const PICKER_HEIGHT = ITEM_HEIGHT * VISIBLE;
-  const pad = Math.floor(VISIBLE / 2);
 
   // 파싱
   const [year, setYear] = useState(initialDate.slice(0, 4));
@@ -41,12 +40,9 @@ const DateSelector: React.FC<Props> = ({
     viewType === "polaroid" ? initialDate.slice(8, 10) : ""
   );
 
-  console.log("[DS] render", { initialDate, year, month, day });
-
   const prevYMRef = useRef({ year, month });
 
   useEffect(() => {
-    console.log("[DS] initialDate effect", { initialDate, viewType });
     const parts = initialDate.split("-");
     setYear(parts[0]);
     setMonth(parts[1] ?? month);
@@ -86,7 +82,6 @@ const DateSelector: React.FC<Props> = ({
   );
 
   useEffect(() => {
-    console.log("[DS] days recalculated", { year, month, days });
     if (viewType !== "polaroid") return;
     if (days.length === 0) return;
     const changedYM =
@@ -104,7 +99,6 @@ const DateSelector: React.FC<Props> = ({
     }
     const date =
       viewType === "polaroid" ? `${year}-${month}-${day}` : `${year}-${month}`;
-    console.log("[DS] emit onChange", date);
     onChange(date);
   }, [year, month, day, viewType, onChange]);
 
@@ -114,9 +108,21 @@ const DateSelector: React.FC<Props> = ({
       : "#ccc";
 
   // 4) 화면에 표시할 문자열 배열
-  const yearOpts = years.map((y) => `${y}년`);
-  const monthOpts = months.map((m) => `${Number(m)}월`);
-  const dayOpts = days.map((d) => `${Number(d)}일`);
+  // helpers
+  const zws = "\u200B";
+  const uniquify = (arr: string[]) => arr.map((t, i) => t + zws.repeat(i + 1));
+
+  // 옵션 문자열
+  const yearOpts = useMemo(() => uniquify(years.map((y) => `${y}년`)), [years]);
+  const monthOpts = useMemo(
+    () => uniquify(months.map((m) => `${Number(m)}월`)),
+    [months]
+  );
+  const dayOpts = useMemo(
+    () => uniquify(days.map((d) => `${Number(d)}일`)),
+    [days]
+  );
+
   return (
     <div
       className={styles.picker}
@@ -141,10 +147,6 @@ const DateSelector: React.FC<Props> = ({
           fontSize={14}
           defaultSelection={years.indexOf(year)}
           updateSelection={(idx: number) => {
-            console.log("[DS] year updateSelection", {
-              idx,
-              value: years[idx],
-            });
             setYear(years[idx]);
           }}
         />
@@ -160,10 +162,6 @@ const DateSelector: React.FC<Props> = ({
           fontSize={14}
           defaultSelection={months.indexOf(month)}
           updateSelection={(idx: number) => {
-            console.log("[DS] month updateSelection", {
-              idx,
-              value: months[idx],
-            });
             setMonth(months[idx].padStart(2, "0"));
           }}
         />
@@ -180,10 +178,6 @@ const DateSelector: React.FC<Props> = ({
             fontSize={14}
             defaultSelection={days.indexOf(day)}
             updateSelection={(idx: number) => {
-              console.log("[DS] day updateSelection", {
-                idx,
-                value: days[idx],
-              });
               setDay(days[idx].padStart(2, "0"));
             }}
           />

--- a/Modi-frontend/src/components/MyPage/Stats/ChartItem/StyleStatsBar.module.css
+++ b/Modi-frontend/src/components/MyPage/Stats/ChartItem/StyleStatsBar.module.css
@@ -31,6 +31,7 @@
 }
 
 .label {
+  width: 55px;
   margin-top: 6px;
   font-size: 14px;
   text-align: center;
@@ -52,7 +53,7 @@
   display: flex;
   flex-direction: row;
   align-items: flex-end;
-  gap: 30px;
+  gap: 20px;
   margin-top: 12px;
 }
 

--- a/Modi-frontend/src/pages/home/PolaroidView.tsx
+++ b/Modi-frontend/src/pages/home/PolaroidView.tsx
@@ -101,12 +101,6 @@ export default function PolaroidView({ onSwitchView }: PolaroidViewProps) {
     }
   }, [tempDate, allDates]);
 
-  // 보여줄 날짜: 가장 최근이 오른쪽 (목업 데이터 사용! allDiaries 대신 mockDiaries만 바꾼 것!)
-  const slides: (DiaryData | null)[] = useMemo(
-    () => allDates.map((d) => diaryMap[d] ?? null),
-    [allDates, diaryMap]
-  );
-
   const indices = [currentIndex - 1, currentIndex, currentIndex + 1];
   // 선택된 월(viewYM)의 일별 목록 로드
   useEffect(() => {
@@ -119,7 +113,6 @@ export default function PolaroidView({ onSwitchView }: PolaroidViewProps) {
         setGroups(sorted);
         setCurrentIndex(sorted.length ? sorted.length - 1 : 0); // 최신 날짜로 포커스
       } catch (error) {
-        console.error("일별 일기 로드 실패:", error);
         setGroups([]);
         setCurrentIndex(0);
       } finally {
@@ -159,7 +152,6 @@ export default function PolaroidView({ onSwitchView }: PolaroidViewProps) {
   };
 
   const handleChange = (newDate: string) => {
-    console.log("[Parent] onChange from DateSelector:", newDate);
     setTempDate(newDate);
   };
 
@@ -294,9 +286,7 @@ export default function PolaroidView({ onSwitchView }: PolaroidViewProps) {
             location="modal"
             label="확인"
             onClick={() => {
-              console.log("[Parent] confirm click", { tempDate });
               const newIdx = allDates.indexOf(tempDate);
-              console.log("[Parent] resolve index", { newIdx });
               if (newIdx !== -1) setCurrentIndex(newIdx);
               setIsSheetOpen(false);
             }}


### PR DESCRIPTION
## Related issue 🛠

closed #<issue_number>
어떤 변경사항이 있었나요?

- [ ] 기능 추가 (Feature)
- [ ] 기능 제거 (Remove)
- [x] 버그 수정 (Bugfix)
- [ ] 리팩토링 (Refactor)
- [ ] 리뷰 반영 (Review Update)
- [ ] 디자인 수정 (Designfix)
- [ ] 문서 작성 및 수정 (Docs: README.md 등)
- [ ] 기능 추가 (Feature)
- [ ] 코드 리팩토링 (Refactor)
- [ ] 개발 환경 설정 (Setting)
- [ ] 테스트 관련 (Test: JUnit 등)

## CheckPoint ✅

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] PR 컨벤션에 맞게 작성했습니다. (필수)
- [x] merge할 브랜치의 위치를 확인해 주세요(main❌/개인작업브랜치⭕) (필수)
- [ ] 버그 수정의 경우, 버그의 원인을 파악하였습니다. (선택)

## Work Description ✏️

- 일기 월별 조회 api로 월별 일기를 불러오다보니 전체 일기가 존재하는 월로 넘어가는 기능이 없었던 것 같아서 이 부분을 수정해서 일기가 존재하는 월 전제를 조회할 수 있도록 수정했습니다.

## Uncompleted Tasks 😅

- [ ] Task1

## To Reviewers 📢

지금 제가 8월 말고는 다른 월의 일기 데이터가 없어서 정상적으로 월 별 일기가 조회가 가능한지 확인해 주시면 감사하겠습니다!
